### PR TITLE
Improve marker label layout: bidirectional placement + accurate measurement

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -5,6 +5,8 @@
 	import { theme, toggleTheme } from '$lib/theme-store.js';
 	import { flaggedCount } from '$lib/flagged-store.js';
 
+	const isDev = import.meta.env.DEV;
+
 	const links = [
 		{ href: '/brands', label: 'Brands' },
 		{ href: '/', label: 'Tablets' },
@@ -20,6 +22,10 @@
 		{ href: '/reference', label: 'Reference' },
 		{ href: '/data-quality', label: 'Data Quality' },
 	];
+
+	const devLinks = [
+		{ href: '/marker-debug', label: 'MarkerDebug' },
+	];
 </script>
 
 <nav>
@@ -27,6 +33,11 @@
 		{#each links as link}
 			<a href="{base}{link.href}" class:active={page.url.pathname === base + link.href}>{link.label}{#if link.dynamic && $flaggedCount > 0}<span class="badge">{$flaggedCount}</span>{/if}</a>
 		{/each}
+		{#if isDev}
+			{#each devLinks as link}
+				<a href="{base}{link.href}" class:active={page.url.pathname === base + link.href} class="dev-link">{link.label}</a>
+			{/each}
+		{/if}
 	</div>
 	<div class="nav-toggles">
 		<button class="unit-toggle" onclick={toggleUnits}>
@@ -73,6 +84,23 @@
 		background: #2563eb;
 		color: #fff;
 		border-color: #2563eb;
+	}
+
+	a.dev-link {
+		border-color: #d97706;
+		color: #d97706;
+	}
+
+	a.dev-link:hover {
+		background: #d97706;
+		color: #fff;
+		border-color: #d97706;
+	}
+
+	a.dev-link.active {
+		background: #d97706;
+		color: #fff;
+		border-color: #d97706;
 	}
 
 	.badge {

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -5,8 +5,6 @@
 	import { theme, toggleTheme } from '$lib/theme-store.js';
 	import { flaggedCount } from '$lib/flagged-store.js';
 
-	const isDev = import.meta.env.DEV;
-
 	const links = [
 		{ href: '/brands', label: 'Brands' },
 		{ href: '/', label: 'Tablets' },
@@ -22,10 +20,6 @@
 		{ href: '/reference', label: 'Reference' },
 		{ href: '/data-quality', label: 'Data Quality' },
 	];
-
-	const devLinks = [
-		{ href: '/marker-debug', label: 'MarkerDebug' },
-	];
 </script>
 
 <nav>
@@ -33,11 +27,6 @@
 		{#each links as link}
 			<a href="{base}{link.href}" class:active={page.url.pathname === base + link.href}>{link.label}{#if link.dynamic && $flaggedCount > 0}<span class="badge">{$flaggedCount}</span>{/if}</a>
 		{/each}
-		{#if isDev}
-			{#each devLinks as link}
-				<a href="{base}{link.href}" class:active={page.url.pathname === base + link.href} class="dev-link">{link.label}</a>
-			{/each}
-		{/if}
 	</div>
 	<div class="nav-toggles">
 		<button class="unit-toggle" onclick={toggleUnits}>
@@ -84,23 +73,6 @@
 		background: #2563eb;
 		color: #fff;
 		border-color: #2563eb;
-	}
-
-	a.dev-link {
-		border-color: #d97706;
-		color: #d97706;
-	}
-
-	a.dev-link:hover {
-		background: #d97706;
-		color: #fff;
-		border-color: #d97706;
-	}
-
-	a.dev-link.active {
-		background: #d97706;
-		color: #fff;
-		border-color: #d97706;
 	}
 
 	.badge {

--- a/src/lib/components/ValueHistogram.svelte
+++ b/src/lib/components/ValueHistogram.svelte
@@ -104,31 +104,65 @@
 	const rangeOpacities = [0.2, 0.35, 0.2, 0.35];
 
 	// Stagger marker labels to avoid overlap
-	const CHAR_WIDTH = 5.5; // approx px per char at font-size 10
+	const CHAR_WIDTH_FALLBACK = 5.5; // used before getComputedTextLength measurements are ready
 	const LABEL_PAD = 8; // extra gap between labels
-	const MARKER_TIERS = 4;
+	const MARKER_TIERS = 6;
+
+	// Measure actual rendered label widths via SVG getComputedTextLength()
+	let uniqueLabels = $derived([...new Set(markers.map(m => m.label))]);
+	let labelMeasureEls: SVGTextElement[] = [];
+	let measuredLabelWidths = $state(new Map<string, number>());
+	$effect(() => {
+		const next = new Map<string, number>();
+		uniqueLabels.forEach((label, i) => {
+			const el = labelMeasureEls[i];
+			if (el) next.set(label, el.getComputedTextLength());
+		});
+		measuredLabelWidths = next;
+	});
+
 	let positionedMarkers = $derived.by(() => {
 		const visible = markers
 			.filter(m => m.value >= scaleMin && m.value <= scaleMax)
-			.map(m => ({ ...m, x: xScale(m.value), labelW: m.label.length * CHAR_WIDTH }))
+			.map(m => ({
+				...m,
+				x: xScale(m.value),
+				labelW: measuredLabelWidths.get(m.label) ?? m.label.length * CHAR_WIDTH_FALLBACK,
+			}))
 			.sort((a, b) => a.x - b.x);
-		// Track the right edge (anchor x) of the last label placed on each tier.
-		// Labels are right-aligned, so a label at x spans [x - labelW, x].
-		// A new label fits on tier i when two conditions hold:
-		//   1. Its left edge clears the previous label on that tier (no text overlap).
-		//   2. No already-placed marker's vertical line passes through its text span
-		//      (a line at px would intersect the label if px >= m.x - m.labelW).
+		// For each tier, track the anchor x of the most recently placed label.
+		// Labels are right-aligned so a label at x spans [x - labelW, x].
 		const tierRightEdge = new Array(MARKER_TIERS).fill(-Infinity);
-		const placedX: number[] = [];
+		const placed: Array<{ x: number; tier: number }> = [];
+
 		return visible.map(m => {
-			let tier = MARKER_TIERS - 1; // fallback: deepest tier
+			const labelLeft = m.x - m.labelW;
+
+			// Pass 1 — strict: no text overlap on the tier AND no earlier marker's
+			// line (which reaches down to that marker's label, crossing our label
+			// area if that marker is on a shallower tier) passes through our span.
+			let tier = -1;
 			for (let i = 0; i < MARKER_TIERS; i++) {
-				const noTextOverlap = m.x - m.labelW >= tierRightEdge[i] + LABEL_PAD;
-				const noLineCrossing = placedX.every(px => px < m.x - m.labelW - LABEL_PAD);
+				const noTextOverlap = labelLeft >= tierRightEdge[i] + LABEL_PAD;
+				const noLineCrossing = placed
+					.filter(p => p.tier < i)
+					.every(p => p.x < labelLeft - LABEL_PAD);
 				if (noTextOverlap && noLineCrossing) { tier = i; break; }
 			}
+
+			// Pass 2 — lenient: when a clean tier isn't available (very dense
+			// markers), accept any tier with no text overlap, ignoring line crossings.
+			if (tier === -1) {
+				for (let i = 0; i < MARKER_TIERS; i++) {
+					if (labelLeft >= tierRightEdge[i] + LABEL_PAD) { tier = i; break; }
+				}
+			}
+
+			// Pass 3 — last resort: deepest tier regardless of overlap.
+			if (tier === -1) tier = MARKER_TIERS - 1;
+
 			tierRightEdge[tier] = m.x;
-			placedX.push(m.x);
+			placed.push({ x: m.x, tier });
 			return { ...m, tier };
 		});
 	});
@@ -189,6 +223,17 @@
 			</button>
 		</div>
 		<svg bind:this={svgEl} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {totalHeight}" class="histogram" style="font-family: 'Google Sans', sans-serif;">
+			<!-- Hidden texts for measuring actual label widths -->
+			{#each uniqueLabels as label, i}
+				<text
+					bind:this={labelMeasureEls[i]}
+					x="0" y="-1000"
+					font-size="10"
+					font-weight="600"
+					visibility="hidden"
+				>{label}</text>
+			{/each}
+
 			{#if title}
 				<text
 					x={width / 2}

--- a/src/lib/components/ValueHistogram.svelte
+++ b/src/lib/components/ValueHistogram.svelte
@@ -138,14 +138,16 @@
 		return visible.map(m => {
 			const labelLeft = m.x - m.labelW;
 
-			// Pass 1 — strict: no text overlap on the tier AND no earlier marker's
-			// line (which reaches down to that marker's label, crossing our label
-			// area if that marker is on a shallower tier) passes through our span.
+			// Pass 1 — strict: no text overlap on the tier AND no already-placed
+			// marker whose line extends down through this tier's label row crosses
+			// our label span. A marker at tier j has its line end at label-row j;
+			// it passes through label-row i only when j > i (deeper tier → longer
+			// line). Shallower-tier (j < i) lines end above row i and cannot cross.
 			let tier = -1;
 			for (let i = 0; i < MARKER_TIERS; i++) {
 				const noTextOverlap = labelLeft >= tierRightEdge[i] + LABEL_PAD;
 				const noLineCrossing = placed
-					.filter(p => p.tier < i)
+					.filter(p => p.tier > i)
 					.every(p => p.x < labelLeft - LABEL_PAD);
 				if (noTextOverlap && noLineCrossing) { tier = i; break; }
 			}

--- a/src/lib/components/ValueHistogram.svelte
+++ b/src/lib/components/ValueHistogram.svelte
@@ -130,43 +130,75 @@
 				labelW: measuredLabelWidths.get(m.label) ?? m.label.length * CHAR_WIDTH_FALLBACK,
 			}))
 			.sort((a, b) => a.x - b.x);
-		// For each tier, track the anchor x of the most recently placed label.
-		// Labels are right-aligned so a label at x spans [x - labelW, x].
-		const tierRightEdge = new Array(MARKER_TIERS).fill(-Infinity);
-		const placed: Array<{ x: number; tier: number }> = [];
 
-		return visible.map(m => {
-			const labelLeft = m.x - m.labelW;
+		if (visible.length === 0) return [];
 
-			// Pass 1 — strict: no text overlap on the tier AND no already-placed
-			// marker whose line extends down through this tier's label row crosses
-			// our label span. A marker at tier j has its line end at label-row j;
-			// it passes through label-row i only when j > i (deeper tier → longer
-			// line). Shallower-tier (j < i) lines end above row i and cannot cross.
-			let tier = -1;
+		// Build alternating-from-both-ends processing order.
+		// Picking from the left end → label sits LEFT of the line (text-anchor="end").
+		// Picking from the right end → label sits RIGHT of the line (text-anchor="start").
+		// This lets markers from each side share tiers, halving tower height.
+		const order: Array<{ m: typeof visible[0]; side: 'left' | 'right' }> = [];
+		for (let lo = 0, hi = visible.length - 1; lo <= hi; lo++, hi--) {
+			order.push({ m: visible[lo], side: 'left' });
+			if (lo !== hi) order.push({ m: visible[hi], side: 'right' });
+		}
+
+		// Per-tier occupation:
+		// leftEdge[i]  — rightmost x of any left-side label on tier i
+		// rightEdge[i] — leftmost  x of any right-side label on tier i
+		const leftEdge  = new Array<number>(MARKER_TIERS).fill(-Infinity);
+		const rightEdge = new Array<number>(MARKER_TIERS).fill(Infinity);
+
+		const placed: Array<{ x: number; tier: number; lL: number; lR: number }> = [];
+		const results = new Map<typeof visible[0], { tier: number; side: 'left' | 'right' }>();
+
+		const tryTier = (
+			m: typeof visible[0], side: 'left' | 'right',
+			lL: number, lR: number, strict: boolean
+		): number => {
 			for (let i = 0; i < MARKER_TIERS; i++) {
-				const noTextOverlap = labelLeft >= tierRightEdge[i] + LABEL_PAD;
-				const noLineCrossing = placed
-					.filter(p => p.tier > i)
-					.every(p => p.x < labelLeft - LABEL_PAD);
-				if (noTextOverlap && noLineCrossing) { tier = i; break; }
-			}
+				// No text overlap with labels already on this tier
+				if (lL < leftEdge[i]  + LABEL_PAD) continue;
+				if (lR > rightEdge[i] - LABEL_PAD) continue;
 
-			// Pass 2 — lenient: when a clean tier isn't available (very dense
-			// markers), accept any tier with no text overlap, ignoring line crossings.
-			if (tier === -1) {
-				for (let i = 0; i < MARKER_TIERS; i++) {
-					if (labelLeft >= tierRightEdge[i] + LABEL_PAD) { tier = i; break; }
+				if (strict) {
+					// Concern 1 — a placed marker's dashed line (at p.x, extending
+					// down to tier p.tier) must not pass through my label span.
+					// Only deeper-tier markers (p.tier > i) reach tier i.
+					const ok1 = placed
+						.filter(p => p.tier > i)
+						.every(p => p.x < lL - LABEL_PAD || p.x > lR + LABEL_PAD);
+					if (!ok1) continue;
+
+					// Concern 2 — my own dashed line (at m.x, reaching down to
+					// tier i) must not pass through any already-placed label at a
+					// shallower tier (p.tier < i), whose label row my line crosses.
+					const ok2 = placed
+						.filter(p => p.tier < i)
+						.every(p => m.x < p.lL - LABEL_PAD || m.x > p.lR + LABEL_PAD);
+					if (!ok2) continue;
 				}
+
+				return i;
 			}
+			return -1;
+		};
 
-			// Pass 3 — last resort: deepest tier regardless of overlap.
-			if (tier === -1) tier = MARKER_TIERS - 1;
+		for (const { m, side } of order) {
+			const lL = side === 'left' ? m.x - m.labelW : m.x;
+			const lR = side === 'left' ? m.x            : m.x + m.labelW;
 
-			tierRightEdge[tier] = m.x;
-			placed.push({ x: m.x, tier });
-			return { ...m, tier };
-		});
+			let tier = tryTier(m, side, lL, lR, true);   // Pass 1 — strict
+			if (tier === -1) tier = tryTier(m, side, lL, lR, false); // Pass 2 — lenient
+			if (tier === -1) tier = MARKER_TIERS - 1;                // Pass 3 — fallback
+
+			if (side === 'left') leftEdge[tier]  = Math.max(leftEdge[tier],  m.x);
+			else                 rightEdge[tier] = Math.min(rightEdge[tier], m.x);
+			placed.push({ x: m.x, tier, lL, lR });
+			results.set(m, { tier, side });
+		}
+
+		return visible.map(m => ({ ...m, ...results.get(m)! }));
 	});
 
 	let svgEl: SVGSVGElement | undefined = $state();
@@ -341,9 +373,9 @@
 					opacity="0.7"
 				/>
 				<text
-					x={marker.x - 4}
+					x={marker.side === 'left' ? marker.x - 4 : marker.x + 4}
 					y={labelY}
-					text-anchor="end"
+					text-anchor={marker.side === 'left' ? 'end' : 'start'}
 					font-size="10"
 					font-weight="600"
 					fill="#e11d48"

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -105,6 +105,20 @@
 	let ptMarkers = $derived(flaggedMarkers('PENTABLET'));
 	let pdMarkers = $derived(flaggedMarkers('PENDISPLAY'));
 
+	let copyFlaggedStatus = $state('');
+	function copyFlaggedList() {
+		const text = flaggedItems
+			.map(t => `${brandName(t.Model.Brand)} ${t.Model.Name} (${t.Model.Id})`)
+			.join('\n');
+		navigator.clipboard.writeText(text).then(() => {
+			copyFlaggedStatus = 'Copied!';
+			setTimeout(() => (copyFlaggedStatus = ''), 2000);
+		}).catch(() => {
+			copyFlaggedStatus = 'Failed';
+			setTimeout(() => (copyFlaggedStatus = ''), 2000);
+		});
+	}
+
 	function copyCompareTable() {
 		const table = document.querySelector('#compare-table');
 		if (table) navigator.clipboard.writeText(table.outerHTML);
@@ -151,6 +165,7 @@
 {#if activeTab === 'flagged'}
 	{#if flaggedItems.length > 0}
 		<div class="flagged-actions">
+			<button class="copy-btn" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</button>
 			<button class="clear-btn" onclick={clearFlags}>Clear all</button>
 		</div>
 		<ul class="flagged-list">

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -152,6 +152,18 @@
 			],
 		},
 		{
+			title: 'Compare page — 6 flagged pen displays (max allowed)',
+			description: 'Simulates the worst case on the compare page: all 6 flagged slots used, all pen displays. With MARKER_TIERS < 6 the 5th and 6th items pile up on the last tier. All 6 should be readable with MARKER_TIERS = 6.',
+			markers: [
+				{ value: 12.6, label: 'Kamvas 12'           },
+				{ value: 13.6, label: 'Wacom One 13'        },
+				{ value: 15.6, label: 'Kamvas 16 GEN3'      },
+				{ value: 15.8, label: 'Artist 16 3rd'       },
+				{ value: 16.0, label: 'Intuos Pro 16'       },
+				{ value: 21.5, label: 'Kamvas 22 Plus'      },
+			],
+		},
+		{
 			title: 'Real data — Huion Kamvas family (flagged tablets)',
 			description: 'Actual diagonals + model names from HUION-tablets.json. Two pairs nearly coincide: Kamvas 13 / Kamvas 13 GEN3 both at 13.27", and Kamvas 16 (2021) / Kamvas 16 GEN3 at 15.55" / 15.81". Long labels like "Kamvas 16 (2021)" (16 chars) make this a realistic stress test.',
 			markers: [

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+	import Nav from '$lib/components/Nav.svelte';
+	import ValueHistogram, { type HistogramRange, type HistogramMarker } from '$lib/components/ValueHistogram.svelte';
+
+	// Shared x-axis ranges (pen display scale, inches)
+	const ranges: HistogramRange[] = [
+		{ label: 'Small',  min: 10, max: 13 },
+		{ label: 'Medium', min: 13, max: 16 },
+		{ label: 'Large',  min: 16, max: 22 },
+		{ label: 'XL',     min: 22, max: 27 },
+	];
+
+	// Synthetic background population — uniform-ish spread across 10–27"
+	function syntheticValues(count = 120): number[] {
+		const vals: number[] = [];
+		for (let i = 0; i < count; i++) {
+			vals.push(10 + (i / (count - 1)) * 17);
+		}
+		return vals;
+	}
+	const bgValues = syntheticValues();
+
+	// ── Test cases ────────────────────────────────────────────────────────────
+
+	interface TestCase {
+		title: string;
+		description: string;
+		markers: HistogramMarker[];
+		currentValue?: number;
+	}
+
+	const testCases: TestCase[] = [
+		{
+			title: 'Single marker',
+			description: 'Baseline — one marker should sit on tier 0 with no issues.',
+			markers: [{ value: 15.6, label: 'CTL-6100' }],
+		},
+		{
+			title: 'Two well-separated markers',
+			description: 'Both should fit on tier 0.',
+			markers: [
+				{ value: 12.1, label: 'CTL-4100' },
+				{ value: 21.5, label: 'CTL-8100' },
+			],
+		},
+		{
+			title: 'Two close markers — slight gap',
+			description: 'Second should drop to tier 1 because labels would overlap on tier 0.',
+			markers: [
+				{ value: 15.4, label: 'KAM13' },
+				{ value: 15.6, label: 'KAM13P' },
+			],
+		},
+		{
+			title: 'Three ascending, evenly spaced',
+			description: 'All three should fit on tier 0 (enough horizontal gap).',
+			markers: [
+				{ value: 11.0, label: 'SMALL' },
+				{ value: 15.6, label: 'MEDIUM' },
+				{ value: 21.5, label: 'LARGE' },
+			],
+		},
+		{
+			title: 'Dense cluster — 5 markers in a narrow band',
+			description: 'Kamvas-style: 12", 13", 15.6", 16", 19". Should spread cleanly across tiers without piling up.',
+			markers: [
+				{ value: 11.9, label: 'KAM12' },
+				{ value: 13.3, label: 'KAM13' },
+				{ value: 15.6, label: 'KAM16' },
+				{ value: 15.8, label: 'KAM16P' },
+				{ value: 19.0, label: 'KAM19' },
+			],
+		},
+		{
+			title: 'Extreme cluster — all at same value',
+			description: 'All five markers at 15.6". Every label should fall on its own tier (or gracefully overlap on deepest tier).',
+			markers: [
+				{ value: 15.6, label: 'AAAA' },
+				{ value: 15.6, label: 'BBBB' },
+				{ value: 15.6, label: 'CCCC' },
+				{ value: 15.6, label: 'DDDD' },
+				{ value: 15.6, label: 'EEEE' },
+			],
+		},
+		{
+			title: 'Two clusters separated by a gap',
+			description: 'Left cluster (10–13") and right cluster (20–23") should each lay out independently.',
+			markers: [
+				{ value: 10.1, label: 'S1' },
+				{ value: 11.0, label: 'S2' },
+				{ value: 12.4, label: 'S3' },
+				{ value: 20.0, label: 'L1' },
+				{ value: 21.5, label: 'L2' },
+				{ value: 22.8, label: 'L3' },
+			],
+		},
+		{
+			title: 'Staircase — each marker slightly to the right of the last',
+			description: 'Labels should prefer tier 0 as soon as there is enough clearance.',
+			markers: [
+				{ value: 10.5, label: 'A' },
+				{ value: 12.0, label: 'BB' },
+				{ value: 13.8, label: 'CCC' },
+				{ value: 15.9, label: 'DDDD' },
+				{ value: 18.2, label: 'EEEEE' },
+				{ value: 21.0, label: 'FFFFFF' },
+			],
+		},
+		{
+			title: 'Long labels in a dense cluster',
+			description: 'Labels are wide strings, so they need more horizontal clearance between tiers.',
+			markers: [
+				{ value: 13.5, label: 'Artist12-2nd' },
+				{ value: 15.6, label: 'Artist16-2nd' },
+				{ value: 15.8, label: 'Artist16-3rd' },
+				{ value: 19.0, label: 'Artist19-2nd' },
+				{ value: 21.5, label: 'Artist22Plus' },
+			],
+		},
+		{
+			title: 'Marker at far left edge',
+			description: 'A marker near x=10 — label should not clip outside the SVG.',
+			markers: [
+				{ value: 10.05, label: 'EDGE' },
+				{ value: 15.6,  label: 'MID'  },
+				{ value: 26.9,  label: 'FAR'  },
+			],
+		},
+		{
+			title: 'With currentValue indicator',
+			description: 'The red current-value line should not conflict visually with nearby marker lines.',
+			markers: [
+				{ value: 15.4, label: 'KAM15' },
+				{ value: 16.0, label: 'KAM16' },
+			],
+			currentValue: 15.6,
+		},
+		{
+			title: 'Maximum stress — 10 markers across the range',
+			description: 'Tests all 6 tiers. No label should be invisible or completely unreadable.',
+			markers: [
+				{ value: 10.1, label: 'T1' },
+				{ value: 11.6, label: 'T2' },
+				{ value: 12.4, label: 'T3' },
+				{ value: 13.3, label: 'T4' },
+				{ value: 14.1, label: 'T5' },
+				{ value: 15.6, label: 'T6' },
+				{ value: 17.3, label: 'T7' },
+				{ value: 19.0, label: 'T8' },
+				{ value: 21.5, label: 'T9' },
+				{ value: 24.0, label: 'T10' },
+			],
+		},
+	];
+</script>
+
+<Nav />
+
+<div class="debug-page">
+	<h1>Marker Layout Debug</h1>
+	<p class="intro">
+		Each section below is a standalone test case for the <code>ValueHistogram</code> marker tier
+		placement algorithm. When changing the algorithm, work through all cases and verify they look
+		correct before merging.
+	</p>
+
+	{#each testCases as tc, i}
+		<section class="test-case">
+			<div class="case-header">
+				<span class="case-num">#{i + 1}</span>
+				<h2>{tc.title}</h2>
+			</div>
+			<p class="case-desc">{tc.description}</p>
+			<div class="marker-list">
+				Markers:
+				{#each tc.markers as m}
+					<span class="marker-chip">{m.label} @ {m.value}"</span>
+				{/each}
+				{#if tc.currentValue !== undefined}
+					<span class="current-chip">currentValue = {tc.currentValue}"</span>
+				{/if}
+			</div>
+			<ValueHistogram
+				values={bgValues}
+				currentValue={tc.currentValue ?? null}
+				{ranges}
+				unit='"'
+				binSize={0.5}
+				bandwidthMultiplier={0.3}
+				markers={tc.markers}
+			/>
+		</section>
+	{/each}
+</div>
+
+<style>
+	.debug-page {
+		padding: 16px;
+	}
+
+	h1 {
+		font-size: 20px;
+		font-weight: 700;
+		margin-bottom: 4px;
+		color: var(--text);
+	}
+
+	.intro {
+		font-size: 13px;
+		color: var(--text-muted);
+		margin-bottom: 24px;
+	}
+
+	.intro code {
+		font-family: monospace;
+		background: var(--bg-card);
+		border: 1px solid var(--border);
+		border-radius: 3px;
+		padding: 1px 4px;
+	}
+
+	.test-case {
+		margin-bottom: 40px;
+		padding: 16px;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--bg-card);
+	}
+
+	.case-header {
+		display: flex;
+		align-items: baseline;
+		gap: 8px;
+		margin-bottom: 4px;
+	}
+
+	.case-num {
+		font-size: 11px;
+		font-weight: 700;
+		color: var(--text-dim);
+		min-width: 24px;
+	}
+
+	h2 {
+		font-size: 14px;
+		font-weight: 700;
+		color: var(--text);
+		margin: 0;
+	}
+
+	.case-desc {
+		font-size: 12px;
+		color: var(--text-muted);
+		margin: 0 0 8px 32px;
+	}
+
+	.marker-list {
+		font-size: 11px;
+		color: var(--text-dim);
+		margin: 0 0 4px 32px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		align-items: center;
+	}
+
+	.marker-chip {
+		background: #fff1f2;
+		border: 1px solid #fecdd3;
+		color: #be123c;
+		border-radius: 4px;
+		padding: 1px 6px;
+		font-family: monospace;
+		font-size: 11px;
+	}
+
+	.current-chip {
+		background: #fef3c7;
+		border: 1px solid #fcd34d;
+		color: #92400e;
+		border-radius: 4px;
+		padding: 1px 6px;
+		font-family: monospace;
+		font-size: 11px;
+	}
+</style>

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -176,15 +176,15 @@
 			],
 		},
 		{
-			title: 'Real data — Huion flagged list with full "Brand Name (ModelId)" labels',
-			description: 'Same 6 tablets as #13 but using the full copy-list label format. Labels are much wider (up to 34 chars for "Huion Inspiroy Giano G930L (G930L)"), stressing the CHAR_WIDTH estimate and tier placement.',
+			title: 'Real data — 6 Huion tablets as shown on compare page',
+			description: 'These 6 tablets flagged together as they appear on the compare page histogram (label = Model.Name). Two coincident pairs at 13.27" and close together at 15.55"/15.81"/16.03" make this the primary real-world stress test.',
 			markers: [
-				{ value: 11.56, label: 'Huion Kamvas 12 (GS1161)'             },
-				{ value: 13.27, label: 'Huion Kamvas 13 (GS1331)'             },
-				{ value: 13.27, label: 'Huion Kamvas 13 GEN3 (GS1333)'        },
-				{ value: 15.55, label: 'Huion Kamvas 16 (2021) (GS1562)'      },
-				{ value: 15.81, label: 'Huion Kamvas 16 GEN3 (GS1563)'        },
-				{ value: 16.03, label: 'Huion Inspiroy Giano G930L (G930L)'   },
+				{ value: 11.56, label: 'Kamvas 12'            },
+				{ value: 13.27, label: 'Kamvas 13'            },
+				{ value: 13.27, label: 'Kamvas 13 GEN3'       },
+				{ value: 15.55, label: 'Kamvas 16 (2021)'     },
+				{ value: 15.81, label: 'Kamvas 16 GEN3'       },
+				{ value: 16.03, label: 'Inspiroy Giano G930L' },
 			],
 		},
 	];

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -27,6 +27,7 @@
 		description: string;
 		markers: HistogramMarker[];
 		currentValue?: number;
+		ranges?: HistogramRange[];
 	}
 
 	const testCases: TestCase[] = [
@@ -178,6 +179,12 @@
 		{
 			title: 'Real data — 6 Huion tablets as shown on compare page',
 			description: 'These 6 tablets flagged together as they appear on the compare page histogram (label = Model.Name). Two coincident pairs at 13.27" and close together at 15.55"/15.81"/16.03" make this the primary real-world stress test.',
+			ranges: [
+				{ label: 'Small',  min:  8, max: 13 },
+				{ label: 'Medium', min: 13, max: 16 },
+				{ label: 'Large',  min: 16, max: 22 },
+				{ label: 'XL',     min: 22, max: 34 },
+			],
 			markers: [
 				{ value: 11.56, label: 'Kamvas 12'            },
 				{ value: 13.27, label: 'Kamvas 13'            },
@@ -219,7 +226,7 @@
 			<ValueHistogram
 				values={bgValues}
 				currentValue={tc.currentValue ?? null}
-				{ranges}
+				ranges={tc.ranges ?? ranges}
 				unit='"'
 				binSize={0.5}
 				bandwidthMultiplier={0.3}

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -136,6 +136,18 @@
 			currentValue: 15.6,
 		},
 		{
+			title: 'Real data — Huion Kamvas family (flagged tablets)',
+			description: 'Actual diagonals from HUION-tablets.json for G930L, GS1161, GS1331, GS1333, GS1562, GS1563. Two pairs nearly coincide (GS1331/GS1333 both 13.27" and GS1562/GS1563 at 15.55"/15.81"), making this a realistic stress test.',
+			markers: [
+				{ value: 11.56, label: 'GS1161' },
+				{ value: 13.27, label: 'GS1331' },
+				{ value: 13.27, label: 'GS1333' },
+				{ value: 15.55, label: 'GS1562' },
+				{ value: 15.81, label: 'GS1563' },
+				{ value: 16.03, label: 'G930L'  },
+			],
+		},
+		{
 			title: 'Maximum stress — 10 markers across the range',
 			description: 'Tests all 6 tiers. No label should be invisible or completely unreadable.',
 			markers: [

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -153,14 +153,14 @@
 		},
 		{
 			title: 'Real data — Huion Kamvas family (flagged tablets)',
-			description: 'Actual diagonals from HUION-tablets.json for G930L, GS1161, GS1331, GS1333, GS1562, GS1563. Two pairs nearly coincide (GS1331/GS1333 both 13.27" and GS1562/GS1563 at 15.55"/15.81"), making this a realistic stress test.',
+			description: 'Actual diagonals + model names from HUION-tablets.json. Two pairs nearly coincide: Kamvas 13 / Kamvas 13 GEN3 both at 13.27", and Kamvas 16 (2021) / Kamvas 16 GEN3 at 15.55" / 15.81". Long labels like "Kamvas 16 (2021)" (16 chars) make this a realistic stress test.',
 			markers: [
-				{ value: 11.56, label: 'GS1161' },
-				{ value: 13.27, label: 'GS1331' },
-				{ value: 13.27, label: 'GS1333' },
-				{ value: 15.55, label: 'GS1562' },
-				{ value: 15.81, label: 'GS1563' },
-				{ value: 16.03, label: 'G930L'  },
+				{ value: 11.56, label: 'Kamvas 12'         },
+				{ value: 13.27, label: 'Kamvas 13'         },
+				{ value: 13.27, label: 'Kamvas 13 GEN3'    },
+				{ value: 15.55, label: 'Kamvas 16 (2021)'  },
+				{ value: 15.81, label: 'Kamvas 16 GEN3'    },
+				{ value: 16.03, label: 'Inspiroy Giano G930L' },
 			],
 		},
 	];

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -136,18 +136,6 @@
 			currentValue: 15.6,
 		},
 		{
-			title: 'Real data — Huion Kamvas family (flagged tablets)',
-			description: 'Actual diagonals from HUION-tablets.json for G930L, GS1161, GS1331, GS1333, GS1562, GS1563. Two pairs nearly coincide (GS1331/GS1333 both 13.27" and GS1562/GS1563 at 15.55"/15.81"), making this a realistic stress test.',
-			markers: [
-				{ value: 11.56, label: 'GS1161' },
-				{ value: 13.27, label: 'GS1331' },
-				{ value: 13.27, label: 'GS1333' },
-				{ value: 15.55, label: 'GS1562' },
-				{ value: 15.81, label: 'GS1563' },
-				{ value: 16.03, label: 'G930L'  },
-			],
-		},
-		{
 			title: 'Maximum stress — 10 markers across the range',
 			description: 'Tests all 6 tiers. No label should be invisible or completely unreadable.',
 			markers: [
@@ -161,6 +149,18 @@
 				{ value: 19.0, label: 'T8' },
 				{ value: 21.5, label: 'T9' },
 				{ value: 24.0, label: 'T10' },
+			],
+		},
+		{
+			title: 'Real data — Huion Kamvas family (flagged tablets)',
+			description: 'Actual diagonals from HUION-tablets.json for G930L, GS1161, GS1331, GS1333, GS1562, GS1563. Two pairs nearly coincide (GS1331/GS1333 both 13.27" and GS1562/GS1563 at 15.55"/15.81"), making this a realistic stress test.',
+			markers: [
+				{ value: 11.56, label: 'GS1161' },
+				{ value: 13.27, label: 'GS1331' },
+				{ value: 13.27, label: 'GS1333' },
+				{ value: 15.55, label: 'GS1562' },
+				{ value: 15.81, label: 'GS1563' },
+				{ value: 16.03, label: 'G930L'  },
 			],
 		},
 	];

--- a/src/routes/marker-debug/+page.svelte
+++ b/src/routes/marker-debug/+page.svelte
@@ -175,6 +175,18 @@
 				{ value: 16.03, label: 'Inspiroy Giano G930L' },
 			],
 		},
+		{
+			title: 'Real data — Huion flagged list with full "Brand Name (ModelId)" labels',
+			description: 'Same 6 tablets as #13 but using the full copy-list label format. Labels are much wider (up to 34 chars for "Huion Inspiroy Giano G930L (G930L)"), stressing the CHAR_WIDTH estimate and tier placement.',
+			markers: [
+				{ value: 11.56, label: 'Huion Kamvas 12 (GS1161)'             },
+				{ value: 13.27, label: 'Huion Kamvas 13 (GS1331)'             },
+				{ value: 13.27, label: 'Huion Kamvas 13 GEN3 (GS1333)'        },
+				{ value: 15.55, label: 'Huion Kamvas 16 (2021) (GS1562)'      },
+				{ value: 15.81, label: 'Huion Kamvas 16 GEN3 (GS1563)'        },
+				{ value: 16.03, label: 'Huion Inspiroy Giano G930L (G930L)'   },
+			],
+		},
 	];
 </script>
 

--- a/src/routes/tablet-families/[entityId]/+page.svelte
+++ b/src/routes/tablet-families/[entityId]/+page.svelte
@@ -59,7 +59,7 @@
 			.map(t => {
 				const d = getDiagonal(t.Digitizer?.Dimensions);
 				if (!d) return null;
-				return { value: isMetric ? d * MM_TO_CM : d * MM_TO_IN, label: t.Model.Id };
+				return { value: isMetric ? d * MM_TO_CM : d * MM_TO_IN, label: t.Model.Name };
 			})
 			.filter((m): m is HistogramMarker => m !== null)
 	);


### PR DESCRIPTION
## Summary

- **Bidirectional placement**: markers are now processed alternating from both ends (smallest, largest, 2nd-smallest, 2nd-largest…). Left-end picks label to the left of the line; right-end picks label to the right. Labels from opposite sides can share a tier row, roughly halving the number of tiers needed and eliminating the \"tower\" staircase effect seen with 5–6 close-together markers.
- **Accurate label widths**: replaced the fixed `5.5px × char-count` estimate with `SVGTextElement.getComputedTextLength()`. Hidden `<text>` elements are rendered and measured after each DOM update via `$effect`, then fed into the placement algorithm. Falls back to the estimate on the brief first render.
- **Line-crossing fix**: the `noLineCrossing` guard was filtering `placed.filter(p => p.tier < i)` (shallower tiers) — but geometrically only deeper-tier marker lines (tier > i) extend far enough to cross a shallower label row. Fixed to `p.tier > i`. Also added a second guard (Concern 2): the current marker's own line must not cross any already-placed label at a shallower tier.
- **Family histogram labels**: switched from `Model.Id` (e.g. `GS1161`) to `Model.Name` (e.g. `Kamvas 12`) on the tablet family detail page.
- **Compare page**: added a \"Copy list\" button to the Flagged tab that copies flagged tablet names as plain text, one per line.
- **MarkerDebug page**: added `/marker-debug` with 14 test cases (not linked from nav; accessible by direct URL during development).

## Test plan

- [ ] Open `/marker-debug` locally and visually check all 14 cases — no label towers, no labels writing over dashed lines
- [ ] Open a tablet family page (e.g. Huion Kamvas GEN3) and confirm the size histogram shows readable bidirectional labels
- [ ] Flag 6 tablets on the compare page, switch to Compare tab, confirm both histograms show all 6 markers cleanly
- [ ] Test \"Copy list\" button on the Flagged tab — verify clipboard content
- [ ] Verify production build completes without errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)