### PR TITLE
Refactor localStorage persistence into shared utility and harden saved view loading

### DIFF
--- a/src/lib/column-widths.ts
+++ b/src/lib/column-widths.ts
@@ -1,14 +1,11 @@
+import { getStorageJson, setStorageJson } from '$lib/storage.js';
+
 const PREFIX = 'drawtabdata-colwidths-';
 
 export function loadColumnWidths(entityType: string): Record<string, number> {
-  try {
-    const raw = localStorage.getItem(PREFIX + entityType);
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
+  return getStorageJson(PREFIX + entityType, {} as Record<string, number>);
 }
 
 export function saveColumnWidths(entityType: string, widths: Record<string, number>) {
-  localStorage.setItem(PREFIX + entityType, JSON.stringify(widths));
+  setStorageJson(PREFIX + entityType, widths);
 }

--- a/src/lib/flagged-store.ts
+++ b/src/lib/flagged-store.ts
@@ -1,21 +1,16 @@
 import { writable, derived } from 'svelte/store';
+import { getStorageJson, setStorageJson } from '$lib/storage.js';
 
 const STORAGE_KEY = 'drawtabdata-flagged-tablets';
 const MAX_FLAGGED = 6;
 
 function load(): string[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
+  const parsed = getStorageJson(STORAGE_KEY, [] as string[]);
+  return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
 }
 
 function persist(ids: string[]) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
-  } catch { /* ignore */ }
+  setStorageJson(STORAGE_KEY, ids);
 }
 
 export const flaggedTablets = writable<string[]>(load());

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,39 @@
+export function getStorageItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setStorageItem(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeStorageItem(key: string): boolean {
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getStorageJson<T>(key: string, fallback: T): T {
+  const raw = getStorageItem(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function setStorageJson<T>(key: string, value: T): boolean {
+  return setStorageItem(key, JSON.stringify(value));
+}

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -1,4 +1,5 @@
 import type { Step } from '$data/lib/pipeline/types.js';
+import { getStorageJson, setStorageJson, removeStorageItem } from '$lib/storage.js';
 
 export interface SavedView {
   name: string;
@@ -12,27 +13,27 @@ function getStorageKey(entityType: string): string {
 }
 
 function migrate(entityType: string) {
-  try {
-    const legacy = localStorage.getItem(LEGACY_KEY);
-    if (legacy) {
-      localStorage.setItem(getStorageKey(entityType), legacy);
-      localStorage.removeItem(LEGACY_KEY);
-    }
-  } catch {}
+  const legacyViews = getStorageJson<SavedView[] | null>(LEGACY_KEY, null);
+  if (!legacyViews) return;
+  setStorageJson(getStorageKey(entityType), legacyViews);
+  removeStorageItem(LEGACY_KEY);
+}
+
+function isValidSavedView(value: unknown): value is SavedView {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.name === 'string' && Array.isArray(entry.steps);
 }
 
 export function loadViews(entityType: string): SavedView[] {
   migrate(entityType);
-  try {
-    const raw = localStorage.getItem(getStorageKey(entityType));
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
+  const raw = getStorageJson<unknown>(getStorageKey(entityType), []);
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isValidSavedView);
 }
 
 function persist(entityType: string, views: SavedView[]) {
-  localStorage.setItem(getStorageKey(entityType), JSON.stringify(views));
+  setStorageJson(getStorageKey(entityType), views);
 }
 
 export function saveView(entityType: string, name: string, steps: Step[]): void {


### PR DESCRIPTION
### Motivation

- Reduce duplicated `localStorage` try/catch + JSON parsing logic and centralize persistence helpers for reuse and consistent error handling.
- Make loading of persisted data more robust against malformed or unexpected values in localStorage to avoid runtime errors and data corruption.

### Description

- Add `src/lib/storage.ts` providing `getStorageItem`, `setStorageItem`, `removeStorageItem`, `getStorageJson`, and `setStorageJson` for safe string and JSON storage access.
- Update `src/lib/column-widths.ts` to use `getStorageJson` / `setStorageJson` instead of ad-hoc `localStorage` access.
- Update `src/lib/flagged-store.ts` to use the storage helpers and filter loaded flagged IDs to strings only to tolerate malformed persisted values.
- Update `src/lib/views.ts` to use the storage helpers, migrate legacy saved views via `getStorageJson`/`setStorageJson`/`removeStorageItem`, and validate loaded view entries with an `isValidSavedView` guard before returning them.

### Testing

- `npm run build` — failed in this environment due to missing `$data/...` dependencies from the `data-repo` submodule and unrelated Svelte accessibility warnings; storage refactor changes themselves do not appear to be the cause of the build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44473bc08832f89df394234e695c9)