### PR TITLE
feat: AlternateNames support + guidebook data merge

### DIFF
--- a/src/lib/components/EntityExplorer.svelte
+++ b/src/lib/components/EntityExplorer.svelte
@@ -159,12 +159,14 @@
 			);
 		}
 
-		// Apply search
+		// Apply search — check visible fields plus any fields marked alwaysSearch
 		if (searchText.trim()) {
 			const q = searchText.trim().toLowerCase();
-			const fieldDefs = r.visibleFields.map(key => fields.find(f => f.key === key)).filter(Boolean);
+			const visibleDefs = r.visibleFields.map(key => fields.find(f => f.key === key)).filter(Boolean);
+			const alwaysDefs = fields.filter(f => f.alwaysSearch && !r.visibleFields.includes(f.key));
+			const searchDefs = [...visibleDefs, ...alwaysDefs];
 			filtered = filtered.filter(row =>
-				fieldDefs.some(f => {
+				searchDefs.some(f => {
 					const val = f!.getValue(row);
 					return val != null && String(val).toLowerCase().includes(q);
 				})

--- a/src/lib/components/TabletPicker.svelte
+++ b/src/lib/components/TabletPicker.svelte
@@ -26,7 +26,8 @@
 			if (filterBrand && t.Model.Brand !== filterBrand) return false;
 			if (filterType && t.Model.Type !== filterType) return false;
 			if (q) {
-				const hay = `${brandName(t.Model.Brand)} ${t.Model.Name} ${t.Model.Id}`.toLowerCase();
+				const altNames = (t.Model.AlternateNames ?? []).join(' ');
+				const hay = `${brandName(t.Model.Brand)} ${t.Model.Name} ${t.Model.Id} ${altNames}`.toLowerCase();
 				if (!hay.includes(q)) return false;
 			}
 			return true;


### PR DESCRIPTION
## Summary
- Add `AlternateNames` search support to `EntityExplorer` and `TabletPicker`
- Wire up `alwaysSearch` flag so alternate names are always searched even when the column isn't visible
- Update data-repo submodule to include all guidebook merge changes

## Changes
- `src/lib/components/EntityExplorer.svelte` — search includes `alwaysSearch` fields
- `src/lib/components/TabletPicker.svelte` — search haystack includes alternate names
- `data-repo` submodule pointer advanced

## Test plan
- [ ] Search for a Bamboo EU alternate name (e.g. "Bamboo Pen & Touch") finds the correct tablet
- [ ] TabletPicker search also finds tablets by alternate name
- [ ] No regressions on filter/sort/export

🤖 Generated with [Claude Code](https://claude.com/claude-code)