### PR TITLE
Rename queriton imports to @thesevenpens/queriton (#207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,10 +267,10 @@ chart alongside the bands charts.
 components that operate on fields generically (FilterBar, SortBar, ColumnBar,
 FilterStep, SortStep, SelectStep, ResultsTable, etc.).
 
-Import from the workspace package `queriton` (see [packages/queriton/](packages/queriton/)):
+Import from the workspace package `@thesevenpens/queriton` (see [packages/queriton/](packages/queriton/)):
 
 ```ts
-import type { AnyFieldDef } from 'queriton';
+import type { AnyFieldDef } from '@thesevenpens/queriton';
 ```
 
 ## EntityId formats

--- a/docs/ANTI-PATTERNS.md
+++ b/docs/ANTI-PATTERNS.md
@@ -6,7 +6,7 @@
 | -------------------------------------------------------------- | ---------------------------------------------------------- |
 | `onMount` + `fetch` for route data                             | `+page.ts` `load()` + `$props().data`                      |
 | Reconstruct `` `${brandName(x)} ${name} (${id})` `` for labels | `penFullName`, `tabletFullName`, etc. via `$lib/*-helpers` |
-| Import from `data-repo/lib/pipeline`                           | `import … from 'queriton'`                                 |
+| Import from `data-repo/lib/pipeline`                           | `import … from '@thesevenpens/queriton'`                   |
 | Edit JSON under `static/`                                      | Edit `data-repo/data/`, run `npm run setup-static`         |
 | `prerender = true` on `/entity/[entityId]` loader              | Keep `prerender = false` (SPA fallback)                    |
 | `structuredClone()` on Svelte 5 proxies in views/pipeline      | `JSON.parse(JSON.stringify(...))` for deep clone           |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,7 +284,7 @@ several files:
 exported from the workspace package `queriton`. Import it as:
 
 ```ts
-import type { AnyFieldDef } from 'queriton';
+import type { AnyFieldDef } from '@thesevenpens/queriton';
 ```
 
 ## Setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,6 +1029,10 @@
 				"vite": "^8.0.0-beta.7 || ^8.0.0"
 			}
 		},
+		"node_modules/@thesevenpens/queriton": {
+			"resolved": "packages/queriton",
+			"link": true
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3295,10 +3299,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/queriton": {
-			"resolved": "packages/queriton",
-			"link": true
-		},
 		"node_modules/queue": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -4204,6 +4204,7 @@
 			"license": "MIT"
 		},
 		"packages/queriton": {
+			"name": "@thesevenpens/queriton",
 			"version": "0.1.0",
 			"license": "ISC",
 			"devDependencies": {

--- a/scripts/setup-static.mjs
+++ b/scripts/setup-static.mjs
@@ -16,7 +16,7 @@ const DATA_DIR = path.join(ROOT, 'data-repo', 'data');
 const QUERITON_DIR = path.join(ROOT, 'packages', 'queriton');
 
 // Warn early if the queriton submodule isn't checked out — every UI/test
-// path imports from 'queriton', and an empty submodule fails confusingly
+// path imports from '@thesevenpens/queriton', and an empty submodule fails confusingly
 // with module-not-found rather than a clear "run submodule update" hint.
 if (!fs.existsSync(path.join(QUERITON_DIR, 'package.json'))) {
 	console.warn(

--- a/src/lib/components/ColumnBar.svelte
+++ b/src/lib/components/ColumnBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type AnyFieldDisplayDef } from 'queriton';
+	import { type AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
 
 	let {

--- a/src/lib/components/DetailView.svelte
+++ b/src/lib/components/DetailView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { AnyFieldDisplayDef } from 'queriton';
+	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import { base } from '$app/paths';
 	import type { ResolvedPathname } from '$app/types';
 	import { unitPreference } from '$lib/unit-store.js';

--- a/src/lib/components/EntityExplorer.svelte
+++ b/src/lib/components/EntityExplorer.svelte
@@ -7,7 +7,7 @@
 		type SelectStep as SelectStepType,
 		type AnyFieldDisplayDef,
 		executePipeline,
-	} from 'queriton';
+	} from '@thesevenpens/queriton';
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 	import QueryPipelineBar from '$lib/components/QueryPipelineBar.svelte';

--- a/src/lib/components/EntityListLayout.svelte
+++ b/src/lib/components/EntityListLayout.svelte
@@ -8,7 +8,7 @@
 	import SubNav from '$lib/components/SubNav.svelte';
 	import EntityExplorer from '$lib/components/EntityExplorer.svelte';
 	import type { SubNavTab } from '$lib/nav/subnav-tabs.js';
-	import type { AnyFieldDisplayDef, Step } from 'queriton';
+	import type { AnyFieldDisplayDef, Step } from '@thesevenpens/queriton';
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	type CellLinkFn = (item: any) => { label: string; href: string }[];

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { AnyFieldDisplayDef } from 'queriton';
+	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import { exportTableAsPptx } from '$lib/pptx-export';
 
 	interface Props {

--- a/src/lib/components/FieldPicker.svelte
+++ b/src/lib/components/FieldPicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { AnyFieldDisplayDef } from 'queriton';
+	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 
 	let {
 		fields,

--- a/src/lib/components/FilterBar.svelte
+++ b/src/lib/components/FilterBar.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import { type AnyFieldDisplayDef, getFieldDef, getOperatorsForField } from 'queriton';
+	import {
+		type AnyFieldDisplayDef,
+		getFieldDef,
+		getOperatorsForField,
+	} from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
 
 	interface FilterItem {

--- a/src/lib/components/FilterStep.svelte
+++ b/src/lib/components/FilterStep.svelte
@@ -4,7 +4,7 @@
 		type FilterStep,
 		getFieldDef,
 		getOperatorsForField,
-	} from 'queriton';
+	} from '@thesevenpens/queriton';
 
 	let {
 		step = $bindable(),

--- a/src/lib/components/QueryPipelineBar.svelte
+++ b/src/lib/components/QueryPipelineBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type AnyFieldDisplayDef, type Step } from 'queriton';
+	import { type AnyFieldDisplayDef, type Step } from '@thesevenpens/queriton';
 	import FilterBar from '$lib/components/FilterBar.svelte';
 	import SortBar from '$lib/components/SortBar.svelte';
 	import ColumnBar from '$lib/components/ColumnBar.svelte';

--- a/src/lib/components/ResultsTable.svelte
+++ b/src/lib/components/ResultsTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type AnyFieldDisplayDef, getFieldDef } from 'queriton';
+	import { type AnyFieldDisplayDef, getFieldDef } from '@thesevenpens/queriton';
 	import { base } from '$app/paths';
 	import type { ResolvedPathname } from '$app/types';
 	import { unitPreference } from '$lib/unit-store.js';

--- a/src/lib/components/SavedViews.svelte
+++ b/src/lib/components/SavedViews.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import type { Step } from 'queriton';
+	import type { Step } from '@thesevenpens/queriton';
 	import { type SavedView, loadViews, saveView, deleteView, renameView } from '$lib/views.js';
 	import { promptModal } from '$lib/modal-store.js';
 

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { AnyFieldDisplayDef } from 'queriton';
+	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 
 	interface QuickFilterOption {
 		fieldDef: AnyFieldDisplayDef;

--- a/src/lib/components/SelectStep.svelte
+++ b/src/lib/components/SelectStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SelectStep, AnyFieldDisplayDef } from 'queriton';
+	import type { SelectStep, AnyFieldDisplayDef } from '@thesevenpens/queriton';
 
 	let {
 		step = $bindable(),

--- a/src/lib/components/SortBar.svelte
+++ b/src/lib/components/SortBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type AnyFieldDisplayDef } from 'queriton';
+	import { type AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
 
 	interface SortItem {

--- a/src/lib/components/SortStep.svelte
+++ b/src/lib/components/SortStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SortStep, AnyFieldDisplayDef } from 'queriton';
+	import type { SortStep, AnyFieldDisplayDef } from '@thesevenpens/queriton';
 
 	let {
 		step = $bindable(),

--- a/src/lib/components/TakeStep.svelte
+++ b/src/lib/components/TakeStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { TakeStep } from 'queriton';
+	import type { TakeStep } from '@thesevenpens/queriton';
 
 	let {
 		step = $bindable(),

--- a/src/lib/views.test.ts
+++ b/src/lib/views.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadViews, saveView, deleteView, renameView } from './views.js';
-import type { Step, SelectStep, SortStep } from 'queriton';
+import type { Step, SelectStep, SortStep } from '@thesevenpens/queriton';
 
 const ENTITY = 'tablets';
 const KEY = `drawtabdata-views-${ENTITY}`;

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -1,4 +1,4 @@
-import type { Step } from 'queriton';
+import type { Step } from '@thesevenpens/queriton';
 import { getStorageJson, setStorageJson, removeStorageItem } from '$lib/storage.js';
 
 export interface SavedView {

--- a/src/routes/data-dictionary/+page.svelte
+++ b/src/routes/data-dictionary/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import Nav from '$lib/components/Nav.svelte';
 	import SubNav from '$lib/components/SubNav.svelte';
-	import type { AnyFieldDisplayDef } from 'queriton';
+	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import { BRAND_FIELDS } from '$data/lib/entities/brand-fields.js';
 	import { TABLET_FIELDS } from '$data/lib/entities/tablet-fields.js';
 	import { TABLET_FAMILY_FIELDS } from '$data/lib/entities/tablet-family-fields.js';


### PR DESCRIPTION
Closes #207. Re-target of [#208](https://github.com/TheSevenPens/DrawTabDataExplorer/pull/208) against \`main\` — the original PR's base branch was squash-merged via [#206](https://github.com/TheSevenPens/DrawTabDataExplorer/pull/206), so #208's content didn't propagate to main and a fresh PR is needed.

## Summary

- **packages/queriton submodule** bumped to [TheSevenPens/queriton@0c259ca](https://github.com/TheSevenPens/queriton/commit/0c259ca) — package renamed to \`@thesevenpens/queriton\` with \`publishConfig.registry\` pointing at GitHub Packages; publish workflow authenticates via the built-in \`GITHUB_TOKEN\`.
- **data-repo submodule** bumped to [TheSevenPens/DrawTabData@1d2ca6b](https://github.com/TheSevenPens/DrawTabData/commit/1d2ca6b) — 14 files updated from \`from 'queriton'\` to \`from '@thesevenpens/queriton'\`.
- **Explorer**: 23 files updated, same find/replace. Touches \`src/\`, \`docs/\`, \`CLAUDE.md\`, \`scripts/setup-static.mjs\`.

This is identical in content to #208; just a cherry-pick onto the post-#206 main.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings (610 files)
- [x] \`npm run test:unit\` — 453 passing (16 files)
- [x] queriton submodule's own \`npm test\` — 227 passing
- [x] \`npm run lint\` — 0 errors (pre-existing warnings only)

## Next step

Once merged, owner pushes a \`v0.1.0\` tag in the queriton repo to trigger the first GitHub Packages publish. No secrets to configure — the workflow uses the auto-provided \`GITHUB_TOKEN\` with \`packages: write\` permission.