### PR TITLE
feat(ui): shared Button + SegmentedControl components (#239)

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	// Shared command button for the app (GitHub #239). Replaces the ~20 one-off
+	// `.copy-btn` / `.add-btn` / `.clear-btn` / `.run-btn` styles scattered across
+	// routes with a small, boring variant set. Body stays a snippet so callers
+	// keep their label/icon markup; styling + a11y live here.
+	import type { Snippet } from 'svelte';
+	import { resolveButtonTitle, type ButtonVariant, type ButtonSize } from './button-helpers.js';
+
+	let {
+		variant = 'secondary',
+		size = 'sm',
+		type = 'button',
+		disabled = false,
+		disabledReason,
+		title,
+		pressed,
+		onclick,
+		children,
+		...rest
+	}: {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+		type?: 'button' | 'submit' | 'reset';
+		disabled?: boolean;
+		/** When disabled, shown as the tooltip so the reason is discoverable. */
+		disabledReason?: string;
+		title?: string;
+		/** aria-pressed for toggle buttons; omit for plain command buttons. */
+		pressed?: boolean;
+		onclick?: (e: MouseEvent) => void;
+		children: Snippet;
+		[key: string]: unknown;
+	} = $props();
+
+	let resolvedTitle = $derived(resolveButtonTitle({ disabled, disabledReason, title }));
+</script>
+
+<button
+	{type}
+	class="btn"
+	class:primary={variant === 'primary'}
+	class:secondary={variant === 'secondary'}
+	class:subtle={variant === 'subtle'}
+	class:danger={variant === 'danger'}
+	class:icon={variant === 'icon'}
+	class:menu-trigger={variant === 'menu-trigger'}
+	class:md={size === 'md'}
+	class:sm={size === 'sm'}
+	{disabled}
+	title={resolvedTitle}
+	aria-pressed={pressed}
+	aria-haspopup={variant === 'menu-trigger' ? 'menu' : undefined}
+	{onclick}
+	{...rest}
+>
+	{@render children()}
+</button>
+
+<style>
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		font-family: inherit;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		line-height: 1;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
+	.btn:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+
+	/* sizes */
+	.btn.sm {
+		padding: 3px 8px;
+		font-size: 12px;
+	}
+	.btn.md {
+		padding: 6px 16px;
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	/* primary — filled accent (run/save/add primary actions) */
+	.btn.primary {
+		background: #2563eb;
+		border-color: #2563eb;
+		color: #fff;
+		font-weight: 600;
+	}
+	.btn.primary:hover:not(:disabled) {
+		background: #1d4ed8;
+		border-color: #1d4ed8;
+	}
+
+	/* secondary — outline accent */
+	.btn.secondary {
+		background: var(--bg-card);
+		border-color: #2563eb;
+		color: #2563eb;
+		font-weight: 600;
+	}
+	.btn.secondary:hover:not(:disabled) {
+		background: #2563eb;
+		color: #fff;
+	}
+
+	/* subtle — neutral, for copy/toolbar commands */
+	.btn.subtle {
+		background: var(--bg-card);
+		border-color: var(--border);
+		color: var(--text-muted);
+	}
+	.btn.subtle:hover:not(:disabled) {
+		background: var(--hover-bg);
+		color: var(--text);
+	}
+
+	/* danger — destructive (clear/delete/remove) */
+	.btn.danger {
+		background: var(--bg-card);
+		border-color: #fca5a5;
+		color: #dc2626;
+	}
+	.btn.danger:hover:not(:disabled) {
+		background: #dc2626;
+		border-color: #dc2626;
+		color: #fff;
+	}
+
+	/* icon — compact, icon-only */
+	.btn.icon {
+		padding: 4px 6px;
+		background: none;
+		border-color: transparent;
+		color: var(--text-muted);
+	}
+	.btn.icon:hover:not(:disabled) {
+		background: var(--hover-bg);
+		color: var(--text);
+	}
+
+	/* menu-trigger — opens an anchored PopoverMenu (#232/#234) */
+	.btn.menu-trigger {
+		background: var(--bg-card);
+		border-color: var(--border);
+		color: var(--text-muted);
+	}
+	.btn.menu-trigger:hover:not(:disabled) {
+		background: var(--hover-bg);
+		color: var(--text);
+	}
+
+	/* toggle pressed state (used with subtle/menu-trigger for view toggles) */
+	.btn[aria-pressed='true'] {
+		color: #6b21a8;
+		border-color: var(--border);
+		font-weight: 600;
+	}
+
+	:global([data-theme='dark']) .btn[aria-pressed='true'] {
+		color: #c4b5fd;
+	}
+</style>

--- a/src/lib/components/JsonTab.svelte
+++ b/src/lib/components/JsonTab.svelte
@@ -4,6 +4,8 @@
   via the "JSON" tab on the detail page rather than a floating dialog.
 -->
 <script lang="ts">
+	import Button from '$lib/components/Button.svelte';
+
 	let { entity }: { entity: Record<string, unknown> } = $props();
 
 	let copied = $state(false);
@@ -18,9 +20,9 @@
 
 <div class="json-tab">
 	<div class="toolbar">
-		<button class="copy-btn" onclick={copyJson} title="Copy JSON to clipboard">
+		<Button variant="subtle" onclick={copyJson} title="Copy JSON to clipboard">
 			{copied ? '✓ Copied' : 'Copy'}
-		</button>
+		</Button>
 	</div>
 	<pre>{json}</pre>
 </div>
@@ -34,19 +36,6 @@
 	.toolbar {
 		display: flex;
 		justify-content: flex-end;
-	}
-	.copy-btn {
-		font-size: 12px;
-		padding: 3px 10px;
-		border: 1px solid var(--border, #bbb);
-		border-radius: 3px;
-		background: var(--bg-card, #f5f5f5);
-		color: var(--text, #333);
-		cursor: pointer;
-	}
-	.copy-btn:hover {
-		border-color: #2563eb;
-		color: #2563eb;
 	}
 	pre {
 		margin: 0;

--- a/src/lib/components/SegmentedControl.svelte
+++ b/src/lib/components/SegmentedControl.svelte
@@ -1,0 +1,78 @@
+<script lang="ts" generics="T extends string">
+	// Shared segmented control for the repeated view/mode toggles (GitHub #239):
+	// JSON↔Table (api-explorer), Summary↔By-unit↔By-sample (PressureRangeTab),
+	// and similar two/three-option switches that each hand-rolled a `.view-toggle`.
+	// Generic over the value type so a `'json' | 'table'` union binds type-safely.
+	interface Option {
+		value: T;
+		label: string;
+	}
+
+	let {
+		options,
+		value = $bindable(),
+		onchange,
+		ariaLabel,
+	}: {
+		options: Option[];
+		value: T;
+		onchange?: (value: T) => void;
+		ariaLabel?: string;
+	} = $props();
+
+	function select(v: T) {
+		if (v === value) return;
+		value = v;
+		onchange?.(v);
+	}
+</script>
+
+<div class="segmented" role="group" aria-label={ariaLabel}>
+	{#each options as opt (opt.value)}
+		<button
+			type="button"
+			class:active={value === opt.value}
+			aria-pressed={value === opt.value}
+			onclick={() => select(opt.value)}>{opt.label}</button
+		>
+	{/each}
+</div>
+
+<style>
+	.segmented {
+		display: inline-flex;
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.segmented button {
+		appearance: none;
+		border: none;
+		background: var(--bg-card);
+		color: var(--text-muted);
+		padding: 2px 10px;
+		font-size: 12px;
+		font-family: inherit;
+		cursor: pointer;
+		border-right: 1px solid var(--border);
+	}
+
+	.segmented button:last-child {
+		border-right: none;
+	}
+
+	.segmented button:hover {
+		color: var(--text);
+	}
+
+	.segmented button.active {
+		background: var(--bg);
+		color: #6b21a8;
+		font-weight: 600;
+	}
+
+	:global([data-theme='dark']) .segmented button.active {
+		color: #c4b5fd;
+	}
+</style>

--- a/src/lib/components/button-helpers.test.ts
+++ b/src/lib/components/button-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { resolveButtonTitle } from './button-helpers.js';
+
+describe('resolveButtonTitle', () => {
+	it('returns the explicit title when not disabled', () => {
+		expect(resolveButtonTitle({ title: 'Copy result' })).toBe('Copy result');
+	});
+
+	it('surfaces the disabled reason as the tooltip when disabled', () => {
+		expect(
+			resolveButtonTitle({ disabled: true, disabledReason: 'Maximum 6 tablets reached' }),
+		).toBe('Maximum 6 tablets reached');
+	});
+
+	it('prefers the disabled reason over an explicit title when disabled', () => {
+		expect(
+			resolveButtonTitle({ disabled: true, disabledReason: 'No rows to export', title: 'Export' }),
+		).toBe('No rows to export');
+	});
+
+	it('falls back to the title when disabled without a reason', () => {
+		expect(resolveButtonTitle({ disabled: true, title: 'Export' })).toBe('Export');
+	});
+
+	it('returns undefined when neither title nor reason applies', () => {
+		expect(resolveButtonTitle({})).toBeUndefined();
+		expect(resolveButtonTitle({ disabledReason: 'reason but not disabled' })).toBeUndefined();
+	});
+});

--- a/src/lib/components/button-helpers.ts
+++ b/src/lib/components/button-helpers.ts
@@ -1,0 +1,21 @@
+// Pure helpers behind Button.svelte (GitHub #239). The variant/size union
+// types are the single source of truth for the button system; resolveButtonTitle
+// holds the one non-obvious behavior (disabled buttons surface their reason as a
+// tooltip), so it lives here and is unit-tested independently of the component.
+
+export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'danger' | 'icon' | 'menu-trigger';
+export type ButtonSize = 'sm' | 'md';
+
+/**
+ * Resolve a button's `title` (tooltip). When a button is disabled and a reason
+ * was supplied, the reason wins so the disabled state is discoverable on hover;
+ * otherwise the explicit title (if any) is used.
+ */
+export function resolveButtonTitle(opts: {
+	disabled?: boolean;
+	disabledReason?: string;
+	title?: string;
+}): string | undefined {
+	if (opts.disabled && opts.disabledReason) return opts.disabledReason;
+	return opts.title;
+}

--- a/src/routes/api-explorer/+page.svelte
+++ b/src/routes/api-explorer/+page.svelte
@@ -6,6 +6,8 @@
 	import QuickApiReference from '$lib/components/QuickApiReference.svelte';
 	import { dataSubNavTabs } from '$lib/nav/subnav-tabs.js';
 	import ExportTableButton from '$lib/components/ExportTableButton.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import SegmentedControl from '$lib/components/SegmentedControl.svelte';
 	import {
 		type Preset,
 		presets,
@@ -164,9 +166,9 @@
 				rows="12"
 			></textarea>
 			<div class="run-row">
-				<button class="run-btn" onclick={runQuery} disabled={running || !ds}>
+				<Button variant="primary" size="md" onclick={runQuery} disabled={running || !ds}>
 					{running ? 'Running…' : 'Run'}
-				</button>
+				</Button>
 				{#if elapsedMs !== null}
 					<span class="meta">{elapsedMs} ms</span>
 				{/if}
@@ -187,20 +189,14 @@
 						<input type="checkbox" bind:checked={showMeta} />
 						Show meta fields
 					</label>
-					<div class="view-toggle" role="group" aria-label="Result view">
-						<button
-							type="button"
-							class:active={viewMode === 'json'}
-							onclick={() => (viewMode = 'json')}
-							aria-pressed={viewMode === 'json'}>JSON</button
-						>
-						<button
-							type="button"
-							class:active={viewMode === 'table'}
-							onclick={() => (viewMode = 'table')}
-							aria-pressed={viewMode === 'table'}>Table</button
-						>
-					</div>
+					<SegmentedControl
+						options={[
+							{ value: 'json', label: 'JSON' },
+							{ value: 'table', label: 'Table' },
+						]}
+						bind:value={viewMode}
+						ariaLabel="Result view"
+					/>
 					{#if viewMode === 'table' && exportTable}
 						<ExportTableButton
 							entityType="api-explorer"
@@ -210,7 +206,7 @@
 							rows={exportTable.rows}
 						/>
 					{/if}
-					<button class="copy-btn" onclick={copyResult}>Copy</button>
+					<Button variant="subtle" onclick={copyResult}>Copy</Button>
 				{/if}
 			</div>
 			{#if error}
@@ -354,45 +350,10 @@
 		margin-top: 8px;
 	}
 
-	.run-btn {
-		padding: 6px 18px;
-		font-size: 13px;
-		font-weight: 600;
-		border: 1px solid #2563eb;
-		border-radius: 4px;
-		background: #2563eb;
-		color: #fff;
-		cursor: pointer;
-	}
-
-	.run-btn:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.run-btn:not(:disabled):hover {
-		background: #1d4ed8;
-	}
-
 	.meta {
 		font-size: 12px;
 		color: var(--text-muted);
 		font-variant-numeric: tabular-nums;
-	}
-
-	.copy-btn {
-		padding: 2px 8px;
-		font-size: 12px;
-		border: 1px solid var(--border);
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		cursor: pointer;
-	}
-
-	.copy-btn:hover {
-		background: var(--hover-bg);
-		color: var(--text);
 	}
 
 	.result-pane {
@@ -446,36 +407,6 @@
 	}
 	.meta-toggle:hover {
 		color: var(--text);
-	}
-
-	.view-toggle {
-		display: inline-flex;
-		gap: 0;
-		border: 1px solid var(--border);
-		border-radius: 4px;
-		overflow: hidden;
-		margin-right: 4px;
-	}
-	.view-toggle button {
-		appearance: none;
-		border: none;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		padding: 2px 10px;
-		font-size: 12px;
-		cursor: pointer;
-		border-right: 1px solid var(--border);
-	}
-	.view-toggle button:last-child {
-		border-right: none;
-	}
-	.view-toggle button:hover {
-		color: var(--text);
-	}
-	.view-toggle button.active {
-		background: var(--bg);
-		color: #6b21a8;
-		font-weight: 600;
 	}
 
 	.table-wrap {


### PR DESCRIPTION
First slice of the UX-architecture epic (#228), per the agreed sequencing (leaves before frames) and the rulings on the [open-decisions comment](https://github.com/TheSevenPens/DrawTabDataExplorer/issues/228#issuecomment-4739180954): #239 ships as a **shared component**, not shared CSS classes, with a boring/narrow API.

## What's here
- **`Button.svelte`** — variants `primary` / `secondary` / `subtle` / `danger` / `icon` / `menu-trigger` (the last for opening the anchored `PopoverMenu` coming in #232/#234), sizes `sm`/`md`, `aria-pressed` for toggles, and a `disabledReason`→tooltip convention so disabled state is discoverable (the #237 ask).
- **`SegmentedControl.svelte`** — generic over the value type so a `'json' | 'table'` union binds type-safely; replaces the hand-rolled `.view-toggle`.
- **`button-helpers.ts`** (+ test) — `resolveButtonTitle`, the one piece of real logic, extracted and unit-tested per the "extracted helpers ship with tests" convention.

## Pilot migrations (deliberately small)
- `/api-explorer`: Run → `primary`, Copy → `subtle`, JSON/Table view-toggle → `SegmentedControl` (removed the local `.run-btn`/`.copy-btn`/`.view-toggle` CSS).
- `JsonTab.svelte`: Copy → `subtle`, to prove cross-file reuse.

Remaining `.copy-btn` (×4), `.add-btn` (×5), `.clear-btn` (×4), `.view-toggle` (×3) call-sites migrate in follow-up PRs — keeping this one reviewable, per the "small PRs, one per child" direction. This is a finish/migrate pass, not new abstraction churn.

## Verification
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · `npm run test:unit` → **558 passed** (5 new) · `npm run test:e2e` → **28 passed**.
- Verified live in the preview: api-explorer Run (`btn primary md`), the SegmentedControl toggling `aria-pressed` + switching to the table view, Copy (`btn subtle sm`), and JsonTab's Copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
