### PR TITLE
feat(ui): EmptyState / StatusMessage / LoadingState components (#237)

### DIFF
--- a/src/lib/components/DetailView.svelte
+++ b/src/lib/components/DetailView.svelte
@@ -4,6 +4,7 @@
 	import type { ResolvedPathname } from '$app/types';
 	import { unitPreference } from '$lib/unit-store.js';
 	import { formatValue, getFieldLabel } from '$data/lib/units.js';
+	import LoadingState from '$lib/components/LoadingState.svelte';
 
 	let {
 		item,
@@ -21,7 +22,7 @@
 </script>
 
 {#if item === null}
-	<p>Loading...</p>
+	<LoadingState />
 {:else}
 	{#each fieldGroups as group (group)}
 		{@const groupFields = fields.filter((f) => f.group === group)}

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	// Shared empty-state message (GitHub #237). Replaces the ~23 inline
+	// `.no-data` / `.empty` paragraphs scattered across detail tabs, compare
+	// pages, and analysis sections. The message is a snippet; an optional
+	// `action` snippet renders a call-to-action below it (e.g. "flag a pen
+	// first") so empty *workflow* states can point the user at what to do next.
+	import type { Snippet } from 'svelte';
+
+	let { children, action }: { children: Snippet; action?: Snippet } = $props();
+</script>
+
+<p class="empty-state">{@render children()}</p>
+{#if action}
+	<div class="empty-action">{@render action()}</div>
+{/if}
+
+<style>
+	.empty-state {
+		font-size: 13px;
+		color: var(--text-dim);
+		font-style: italic;
+		margin: 0;
+	}
+
+	.empty-action {
+		margin-top: 8px;
+	}
+</style>

--- a/src/lib/components/LoadingState.svelte
+++ b/src/lib/components/LoadingState.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	// Shared loading placeholder (GitHub #237). Standardizes the ad-hoc
+	// "Loading..." paragraphs (e.g. DetailView, sectioned pages) into one muted
+	// style. Defaults to "Loading…"; pass children to override the copy.
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children?: Snippet } = $props();
+</script>
+
+<p class="loading-state">
+	{#if children}{@render children()}{:else}Loading…{/if}
+</p>
+
+<style>
+	.loading-state {
+		font-size: 13px;
+		color: var(--text-dim);
+		font-style: italic;
+		margin: 0;
+	}
+</style>

--- a/src/lib/components/PenDetail.svelte
+++ b/src/lib/components/PenDetail.svelte
@@ -14,6 +14,7 @@
 	import PressureResponseChartLegendTable from '$lib/components/PressureResponseChartLegendTable.svelte';
 	import FlagButton from '$lib/components/FlagButton.svelte';
 	import PressureRangeTab from '$lib/components/PressureRangeTab.svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import {
 		tabletFullName,
 		buildTabletNameMap,
@@ -230,7 +231,7 @@
 				</tbody>
 			</table>
 		{:else}
-			<p class="no-data">You don't own a unit of this pen model.</p>
+			<EmptyState>You don't own a unit of this pen model.</EmptyState>
 		{/if}
 	</div>
 {/if}
@@ -302,7 +303,7 @@
 				{defectsByInventoryId}
 			/>
 		{:else}
-			<p class="no-data">No pressure response data available for this pen model.</p>
+			<EmptyState>No pressure response data available for this pen model.</EmptyState>
 		{/if}
 	</div>
 {/if}
@@ -397,12 +398,6 @@
 		border-radius: 4px;
 		background: var(--bg-card);
 		color: var(--text);
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 
 	.compat-table {

--- a/src/lib/components/StatusMessage.svelte
+++ b/src/lib/components/StatusMessage.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	// Shared status line for inline good/warning/error/info notices (GitHub #237).
+	// Replaces the per-route `.good` success text (and ad-hoc warning/error
+	// paragraphs) with one consistent visual language. Message is a snippet so
+	// callers keep their wording/markup.
+	import type { Snippet } from 'svelte';
+
+	type Variant = 'good' | 'warning' | 'error' | 'info';
+
+	let { variant = 'info', children }: { variant?: Variant; children: Snippet } = $props();
+</script>
+
+<p
+	class="status"
+	class:good={variant === 'good'}
+	class:warning={variant === 'warning'}
+	class:error={variant === 'error'}
+	class:info={variant === 'info'}
+	role={variant === 'error' ? 'alert' : undefined}
+>
+	{@render children()}
+</p>
+
+<style>
+	.status {
+		font-size: 14px;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.good {
+		color: #16a34a;
+	}
+	.warning {
+		color: #d97706;
+	}
+	.error {
+		color: #dc2626;
+	}
+	.info {
+		color: var(--text-muted);
+		font-weight: 400;
+	}
+</style>

--- a/src/routes/data-quality/+page.svelte
+++ b/src/routes/data-quality/+page.svelte
@@ -8,6 +8,8 @@
 	import { analyzeData } from '$lib/data-quality/analysis.js';
 	import SectionHeader from '$lib/data-quality/SectionHeader.svelte';
 	import CompletionSection from '$lib/data-quality/CompletionSection.svelte';
+	import StatusMessage from '$lib/components/StatusMessage.svelte';
+	import LoadingState from '$lib/components/LoadingState.svelte';
 
 	const dataTabs = dataSubNavTabs();
 
@@ -145,7 +147,7 @@
 	<h1>Data Quality</h1>
 
 	{#if !ds}
-		<p>Loading...</p>
+		<LoadingState />
 	{:else}
 		<SectionedPage sections={sectionDefs} defaultSection="entity-counts">
 			{#snippet content(activeSection: string)}
@@ -188,7 +190,7 @@
 								)}
 						/>
 						{#if issues.length === 0}
-							<p class="good">No issues found.</p>
+							<StatusMessage variant="good">No issues found.</StatusMessage>
 						{:else}
 							<table>
 								<thead>
@@ -230,7 +232,7 @@
 							IDs in pen-compat that don't match any record in the referenced entity.
 						</p>
 						{#if orphanedCompat.length === 0}
-							<p class="good">No orphaned references.</p>
+							<StatusMessage variant="good">No orphaned references.</StatusMessage>
 						{:else}
 							<table class="compact">
 								<thead><tr><th>Type</th><th>ID</th></tr></thead>
@@ -260,7 +262,9 @@
 						/>
 						<p class="description">Wacom tablets that have no entries in pen-compat.</p>
 						{#if tabletsNoCompat.length === 0}
-							<p class="good">All Wacom tablets have compatibility data.</p>
+							<StatusMessage variant="good"
+								>All Wacom tablets have compatibility data.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead><tr><th>Model ID</th><th>Name</th></tr></thead>
@@ -290,7 +294,7 @@
 						/>
 						<p class="description">Pens that have no entries in pen-compat.</p>
 						{#if pensNoCompat.length === 0}
-							<p class="good">All pens have compatibility data.</p>
+							<StatusMessage variant="good">All pens have compatibility data.</StatusMessage>
 						{:else}
 							<table class="compact">
 								<thead><tr><th>Pen ID</th><th>Name</th></tr></thead>
@@ -329,7 +333,9 @@
 							with its tablet.
 						</p>
 						{#if includedPenMissingCompat.length === 0}
-							<p class="good">All included pens have a matching pen-compat row.</p>
+							<StatusMessage variant="good"
+								>All included pens have a matching pen-compat row.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -373,7 +379,7 @@
 							Family IDs referenced by pens or tablets that don't exist in the family entities.
 						</p>
 						{#if orphanedFamilies.length === 0}
-							<p class="good">No orphaned family references.</p>
+							<StatusMessage variant="good">No orphaned family references.</StatusMessage>
 						{:else}
 							<table class="compact">
 								<thead><tr><th>Type</th><th>Family ID</th><th>Referenced By</th></tr></thead>
@@ -421,7 +427,9 @@
 							line and interpolation can return wrong results.
 						</p>
 						{#if nonMonotonicSessions.length === 0}
-							<p class="good">All sessions are monotonically non-decreasing on both axes.</p>
+							<StatusMessage variant="good"
+								>All sessions are monotonically non-decreasing on both axes.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -495,7 +503,9 @@
 							The Piaf estimate may be unreliable for these.
 						</p>
 						{#if missingLowEndPens.length === 0}
-							<p class="good">All pens have low-end measurements covering the activation point.</p>
+							<StatusMessage variant="good"
+								>All pens have low-end measurements covering the activation point.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -545,7 +555,9 @@
 							Pens with only one recorded session. A second session would confirm consistency.
 						</p>
 						{#if singleSessionPens.length === 0}
-							<p class="good">Every pen has at least two sessions on record.</p>
+							<StatusMessage variant="good"
+								>Every pen has at least two sessions on record.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -598,7 +610,9 @@
 							measurement yet — prime candidates for measuring directly.
 						</p>
 						{#if iafEstimatedNoMeasurement.length === 0}
-							<p class="good">Every unit with an IAF estimate also has a direct measurement.</p>
+							<StatusMessage variant="good"
+								>Every unit with an IAF estimate also has a direct measurement.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -653,7 +667,8 @@
 							invalidate older curves.
 						</p>
 						{#if staleMeasurements.length === 0}
-							<p class="good">Every pen has a session in the last year.</p>
+							<StatusMessage variant="good">Every pen has a session in the last year.</StatusMessage
+							>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -709,7 +724,7 @@
 							reasons appear first.
 						</p>
 						{#if remeasureRecommendations.length === 0}
-							<p class="good">No pens need re-measurement.</p>
+							<StatusMessage variant="good">No pens need re-measurement.</StatusMessage>
 						{:else}
 							<table class="compact">
 								<thead>
@@ -858,12 +873,6 @@
 		font-size: 13px;
 		color: #888;
 		margin-bottom: 8px;
-	}
-
-	.good {
-		font-size: 14px;
-		color: #16a34a;
-		font-weight: 600;
 	}
 
 	table {


### PR DESCRIPTION
Second slice of the UX-architecture epic (#228), continuing the agreed leaves-before-frames order (after #239 / [PR #241](https://github.com/TheSevenPens/DrawTabDataExplorer/pull/241)). Standardizes the scattered empty/success/loading states into three small presentational primitives.

## What's here
- **`StatusMessage.svelte`** — `good` / `warning` / `error` / `info` variants (error gets `role="alert"`). Message is a snippet so callers keep their wording.
- **`EmptyState.svelte`** — muted empty message + an optional **`action` snippet** for empty *workflow* states ("flag a pen first") so they can point the user at the next step (the #237 ask). The action being a snippet means this does **not** depend on the #239 `Button` — the two PRs merge in any order.
- **`LoadingState.svelte`** — consistent muted "Loading…" (overridable via children).

## Pilot migrations (deliberately small)
- `/data-quality`: all **12 `.good`** success lines → `StatusMessage variant="good"`, top-level loading → `LoadingState`, dead `.good` CSS removed.
- `DetailView.svelte`: `Loading...` → `LoadingState`.
- `PenDetail.svelte`: both `.no-data` paragraphs → `EmptyState`, dead `.no-data` CSS removed.

Remaining `.no-data`/`.empty` call-sites (compare pages, other detail tabs, analysis sections) migrate in follow-ups — keeping this reviewable, per the "small PRs, one per child, finish/migrate not churn" direction.

## Verification
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · unit + **28 e2e** green.
- Verified live in the preview: StatusMessage good = `rgb(22,163,74)`/weight 600 (exact `.good` match), EmptyState = `var(--text-dim)` italic 13px (exact `.no-data` match) on an Apple pen with no owned unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
