### PR TITLE
feat(ui): EntityLink component for canonical entity links (#238)

### DIFF
--- a/src/lib/components/BrandDetail.svelte
+++ b/src/lib/components/BrandDetail.svelte
@@ -3,6 +3,7 @@
 	import { type Brand, BRAND_FIELDS, BRAND_FIELD_GROUPS } from '$data/lib/entities/brand-fields.js';
 	import { type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
 	import DetailView from '$lib/components/DetailView.svelte';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import ExportTableButton from '$lib/components/ExportTableButton.svelte';
 	import Nav from '$lib/components/Nav.svelte';
 	import Tabs, { type Tab } from '$lib/components/Tabs.svelte';
@@ -90,13 +91,7 @@
 					<tbody>
 						{#each sortedTablets as t (t.Meta.EntityId)}
 							<tr>
-								<td
-									><a
-										class="entity-link"
-										href={resolve('/entity/[entityId]', { entityId: t.Meta.EntityId })}
-										>{tabletNameAndId(t)}</a
-									></td
-								>
+								<td><EntityLink entityId={t.Meta.EntityId}>{tabletNameAndId(t)}</EntityLink></td>
 								<td>{(t.Model.AlternateNames ?? []).join(', ')}</td>
 								<td>{t.Model.Type}</td>
 								<td>{t.Model.LaunchYear ?? ''}</td>
@@ -129,12 +124,7 @@
 					<tbody>
 						{#each sortedPens as p (p.EntityId)}
 							<tr>
-								<td
-									><a
-										class="entity-link"
-										href={resolve('/entity/[entityId]', { entityId: p.EntityId })}>{p.PenName}</a
-									></td
-								>
+								<td><EntityLink entityId={p.EntityId}>{p.PenName}</EntityLink></td>
 								<td>{p.PenId}</td>
 								<td>{p.PenYear ?? ''}</td>
 							</tr>
@@ -233,14 +223,6 @@
 	td {
 		padding: 5px 10px;
 		border-bottom: 1px solid var(--border);
-	}
-
-	.entity-link {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.entity-link:hover {
-		text-decoration: underline;
 	}
 
 	.no-data {

--- a/src/lib/components/EntityLink.svelte
+++ b/src/lib/components/EntityLink.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	// Canonical link to an entity's detail page (GitHub #238). Centralizes the
+	// `resolve('/entity/[entityId]', ...)` call and the shared link styling that
+	// ~20 files were repeating inline. The *label* stays a snippet — callers pass
+	// it from the canonical formatters (penFullName/tabletFullName/…); this
+	// component never reconstructs a display name (see CLAUDE.md "Label
+	// formatting"). For data-shaped links (e.g. ResultsTable cellLinks) use the
+	// route's own href building; this is for markup `<a>` usages.
+	import { resolve } from '$app/paths';
+	import type { Snippet } from 'svelte';
+
+	let {
+		entityId,
+		title,
+		children,
+	}: {
+		entityId: string;
+		title?: string;
+		children: Snippet;
+	} = $props();
+
+	let href = $derived(resolve('/entity/[entityId]', { entityId }));
+</script>
+
+<a {href} {title} class="entity-link">{@render children()}</a>
+
+<style>
+	.entity-link {
+		color: var(--link);
+		text-decoration: none;
+	}
+	.entity-link:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/src/lib/components/tablet-detail/TabletModelTab.svelte
+++ b/src/lib/components/tablet-detail/TabletModelTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { type Tablet } from '$data/lib/drawtab-loader.js';
 	import { TABLET_FIELDS } from '$data/lib/entities/tablet-fields.js';
 	import { type TabletFamily } from '$data/lib/entities/tablet-family-fields.js';
@@ -49,14 +49,10 @@
 											{#each includedPenItems as pen, i (pen.entityId)}
 												{#if i > 0},
 												{/if}
-												<a href={resolve('/entity/[entityId]', { entityId: pen.entityId })}
-													>{pen.name}</a
-												>
+												<EntityLink entityId={pen.entityId}>{pen.name}</EntityLink>
 											{/each}
 										{:else if f.key === 'ModelFamily' && family}
-											<a href={resolve('/entity/[entityId]', { entityId: family.EntityId })}
-												>{family.FamilyName}</a
-											>
+											<EntityLink entityId={family.EntityId}>{family.FamilyName}</EntityLink>
 										{:else if isUrl(val)}
 											<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 											<a href={val} target="_blank" rel="noopener">


### PR DESCRIPTION
Third slice of the UX-architecture epic (#228), continuing the leaves-before-frames order (after #239 and #237). Centralizes the most-repeated pattern in the app: `resolve('/entity/[entityId]', ...)` + `.entity-link` styling, inline across ~20 files (54 sites).

## What's here
- **`EntityLink.svelte`** — wraps the `resolve()` call and the shared `var(--link)` styling. The **label stays a snippet**, so callers keep passing it from the canonical formatters (`tabletNameAndId`/`penFullName`/…) — the component never reconstructs a display name (the CLAUDE.md "Label formatting" rule, now enforced at the rendering layer too).

## Pilot migrations (deliberately small)
- `BrandDetail.svelte`: both table-cell entity links → `EntityLink`, dead local `.entity-link` CSS removed. The bespoke `.tl-item` timeline cards are left as-is (different shape).
- `TabletModelTab.svelte`: family + included-pen links → `EntityLink`; unused `resolve` import dropped. The external-URL `<a>` keeps the local `dd a` styling.

Remaining ~18 files with inline `/entity/[entityId]` links migrate in follow-ups. Data-shaped links (`ResultsTable` `cellLinks`) keep building hrefs in route code by design — `EntityLink` is for markup `<a>` usages, per the #238 acceptance note.

## Verification
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · **558 unit · 28 e2e**.
- Verified live in preview: BrandDetail tablet/pen table links and TabletModelTab family/included-pen links resolve to the correct `/entity/...` URLs at `rgb(37,99,235)` (`var(--link)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
