### PR TITLE
feat(ui): shared PopoverMenu for query-pill context menus (#232, #234)

### DIFF
--- a/src/lib/components/ColumnBar.svelte
+++ b/src/lib/components/ColumnBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
+	import PopoverMenu from '$lib/components/PopoverMenu.svelte';
 	import { moveItem } from '$lib/pill-dnd.js';
 
 	let {
@@ -95,8 +96,6 @@
 	}
 </script>
 
-<svelte:window onclick={() => (contextMenu = null)} />
-
 <div class="toolbar-item">
 	<button class="toolbar-btn col-btn" class:open={isOpen} onclick={ontoggle}>
 		Columns<span class="badge col-badge">{columns.length}</span>
@@ -153,13 +152,17 @@
 </div>
 
 {#if contextMenu}
-	<div class="context-menu" style="left: {contextMenu.x}px; top: {contextMenu.y}px;">
-		<button class="delete" onclick={() => remove(contextMenu!.index)}>Remove</button>
-		<hr />
-		<button class="delete" onclick={() => removeGroup(contextMenu!.index)}
-			>Remove all {getGroupName(contextMenu.index)}</button
-		>
-	</div>
+	{@const idx = contextMenu.index}
+	<PopoverMenu
+		x={contextMenu.x}
+		y={contextMenu.y}
+		items={[
+			{ label: 'Remove', danger: true, onclick: () => remove(idx) },
+			{ divider: true },
+			{ label: `Remove all ${getGroupName(idx)}`, danger: true, onclick: () => removeGroup(idx) },
+		]}
+		onclose={() => (contextMenu = null)}
+	/>
 {/if}
 
 <style>
@@ -280,40 +283,5 @@
 	}
 	.add-wrapper {
 		position: relative;
-	}
-
-	.context-menu {
-		position: fixed;
-		background: var(--bg-card);
-		border: 1px solid var(--border-light);
-		border-radius: 6px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		z-index: 200;
-		min-width: 150px;
-	}
-	.context-menu button {
-		display: block;
-		width: 100%;
-		text-align: left;
-		padding: 6px 12px;
-		font-size: 13px;
-		border: none;
-		background: none;
-		cursor: pointer;
-		color: var(--text);
-	}
-	.context-menu button:hover {
-		background: var(--hover-bg);
-	}
-	.context-menu button.delete {
-		color: #e11d48;
-	}
-	.context-menu button.delete:hover {
-		background: #fef2f2;
-	}
-	.context-menu hr {
-		border: none;
-		border-top: 1px solid var(--border);
-		margin: 2px 0;
 	}
 </style>

--- a/src/lib/components/FilterBar.svelte
+++ b/src/lib/components/FilterBar.svelte
@@ -5,6 +5,7 @@
 		getOperatorsForField,
 	} from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
+	import PopoverMenu from '$lib/components/PopoverMenu.svelte';
 
 	interface FilterItem {
 		field: string;
@@ -129,8 +130,6 @@
 	}
 </script>
 
-<svelte:window onclick={() => (contextMenu = null)} />
-
 <div class="toolbar-item">
 	<button
 		class="toolbar-btn filter-btn"
@@ -223,20 +222,27 @@
 </div>
 
 {#if contextMenu}
-	<div class="context-menu" style="left: {contextMenu.x}px; top: {contextMenu.y}px;">
-		<button
-			onclick={() => {
-				editingIndex = contextMenu!.index;
-				if (!isOpen) ontoggle();
-				contextMenu = null;
-			}}>Edit</button
-		>
-		<button onclick={() => toggleDisabled(contextMenu!.index)}>
-			{filters[contextMenu.index]?.disabled ? 'Enable' : 'Disable'}
-		</button>
-		<hr />
-		<button class="delete" onclick={() => removeFilter(contextMenu!.index)}>Remove</button>
-	</div>
+	{@const idx = contextMenu.index}
+	<PopoverMenu
+		x={contextMenu.x}
+		y={contextMenu.y}
+		items={[
+			{
+				label: 'Edit',
+				onclick: () => {
+					editingIndex = idx;
+					if (!isOpen) ontoggle();
+				},
+			},
+			{
+				label: filters[idx]?.disabled ? 'Enable' : 'Disable',
+				onclick: () => toggleDisabled(idx),
+			},
+			{ divider: true },
+			{ label: 'Remove', danger: true, onclick: () => removeFilter(idx) },
+		]}
+		onclose={() => (contextMenu = null)}
+	/>
 {/if}
 
 <style>
@@ -417,40 +423,5 @@
 	.done-btn:hover {
 		background: #d97706;
 		color: #fff;
-	}
-
-	.context-menu {
-		position: fixed;
-		background: var(--bg-card);
-		border: 1px solid var(--border-light);
-		border-radius: 6px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		z-index: 200;
-		min-width: 150px;
-	}
-	.context-menu button {
-		display: block;
-		width: 100%;
-		text-align: left;
-		padding: 6px 12px;
-		font-size: 13px;
-		border: none;
-		background: none;
-		cursor: pointer;
-		color: var(--text);
-	}
-	.context-menu button:hover {
-		background: var(--hover-bg);
-	}
-	.context-menu button.delete {
-		color: #e11d48;
-	}
-	.context-menu button.delete:hover {
-		background: #fef2f2;
-	}
-	.context-menu hr {
-		border: none;
-		border-top: 1px solid var(--border);
-		margin: 2px 0;
 	}
 </style>

--- a/src/lib/components/PopoverMenu.svelte
+++ b/src/lib/components/PopoverMenu.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	// Anchored popover menu (GitHub #232/#234). One shared dismiss / position /
+	// Escape behavior for the query-pill context menus (FilterBar, SortBar,
+	// ColumnBar) that each hand-rolled an identical `.context-menu`. Positioned
+	// at a fixed (x, y); the menu items are plain data, so callers keep their
+	// per-bar actions while the rendering and dismissal live here.
+	interface MenuAction {
+		label: string;
+		onclick: () => void;
+		/** Render in the destructive (red) style, e.g. Remove. */
+		danger?: boolean;
+	}
+	interface MenuDivider {
+		divider: true;
+	}
+	type MenuItem = MenuAction | MenuDivider;
+
+	let {
+		x,
+		y,
+		items,
+		onclose,
+	}: {
+		x: number;
+		y: number;
+		items: MenuItem[];
+		onclose: () => void;
+	} = $props();
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
+</script>
+
+<!-- Any click (in or out) dismisses, matching the prior per-bar behavior; a
+     selected item runs its action first, then closes. Escape also closes. -->
+<svelte:window onclick={onclose} onkeydown={onKeydown} />
+
+<div class="context-menu" role="menu" style="left: {x}px; top: {y}px;">
+	{#each items as item, i (i)}
+		{#if 'divider' in item}
+			<hr />
+		{:else}
+			<button
+				type="button"
+				role="menuitem"
+				class:delete={item.danger}
+				onclick={() => {
+					item.onclick();
+					onclose();
+				}}>{item.label}</button
+			>
+		{/if}
+	{/each}
+</div>
+
+<style>
+	.context-menu {
+		position: fixed;
+		background: var(--bg-card);
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		z-index: 200;
+		min-width: 150px;
+	}
+	.context-menu button {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: 6px 12px;
+		font-size: 13px;
+		border: none;
+		background: none;
+		cursor: pointer;
+		color: var(--text);
+	}
+	.context-menu button:hover {
+		background: var(--hover-bg);
+	}
+	.context-menu button.delete {
+		color: #e11d48;
+	}
+	.context-menu button.delete:hover {
+		background: #fef2f2;
+	}
+	.context-menu hr {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 2px 0;
+	}
+</style>

--- a/src/lib/components/SortBar.svelte
+++ b/src/lib/components/SortBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type AnyFieldDisplayDef } from '@thesevenpens/queriton';
 	import FieldPicker from '$lib/components/FieldPicker.svelte';
+	import PopoverMenu from '$lib/components/PopoverMenu.svelte';
 	import { moveItem } from '$lib/pill-dnd.js';
 
 	interface SortItem {
@@ -109,8 +110,6 @@
 	}
 </script>
 
-<svelte:window onclick={() => (contextMenu = null)} />
-
 <div class="toolbar-item">
 	<button
 		class="toolbar-btn sort-btn"
@@ -182,12 +181,18 @@
 </div>
 
 {#if contextMenu}
-	<div class="context-menu" style="left: {contextMenu.x}px; top: {contextMenu.y}px;">
-		<button onclick={() => setDirection(contextMenu!.index, 'asc')}>Sort Ascending</button>
-		<button onclick={() => setDirection(contextMenu!.index, 'desc')}>Sort Descending</button>
-		<hr />
-		<button class="delete" onclick={() => remove(contextMenu!.index)}>Remove</button>
-	</div>
+	{@const idx = contextMenu.index}
+	<PopoverMenu
+		x={contextMenu.x}
+		y={contextMenu.y}
+		items={[
+			{ label: 'Sort Ascending', onclick: () => setDirection(idx, 'asc') },
+			{ label: 'Sort Descending', onclick: () => setDirection(idx, 'desc') },
+			{ divider: true },
+			{ label: 'Remove', danger: true, onclick: () => remove(idx) },
+		]}
+		onclose={() => (contextMenu = null)}
+	/>
 {/if}
 
 <style>
@@ -316,40 +321,5 @@
 	}
 	.add-wrapper {
 		position: relative;
-	}
-
-	.context-menu {
-		position: fixed;
-		background: var(--bg-card);
-		border: 1px solid var(--border-light);
-		border-radius: 6px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		z-index: 200;
-		min-width: 150px;
-	}
-	.context-menu button {
-		display: block;
-		width: 100%;
-		text-align: left;
-		padding: 6px 12px;
-		font-size: 13px;
-		border: none;
-		background: none;
-		cursor: pointer;
-		color: var(--text);
-	}
-	.context-menu button:hover {
-		background: var(--hover-bg);
-	}
-	.context-menu button.delete {
-		color: #e11d48;
-	}
-	.context-menu button.delete:hover {
-		background: #fef2f2;
-	}
-	.context-menu hr {
-		border: none;
-		border-top: 1px solid var(--border);
-		margin: 2px 0;
 	}
 </style>


### PR DESCRIPTION
Fourth slice of the UX-architecture epic (#228). FilterBar, SortBar, and ColumnBar each hand-rolled a **byte-identical** `.context-menu` (a positioned `{x,y}` div + a `<svelte:window onclick>` dismiss + duplicated CSS), differing only in their menu items. This extracts one anchored `PopoverMenu` — the shared primitive #232 and #234 both call for.

## What's here
- **`PopoverMenu.svelte`** — props `x` / `y` / `items` / `onclose`. Items are `{ label, onclick, danger? }` or `{ divider: true }`. Owns positioning, dismissal (outside-click **and** Escape — the bars only had outside-click), and the menu styling.
- **FilterBar / SortBar / ColumnBar** — drop their local menu markup, window handler, and `.context-menu` CSS; render `<PopoverMenu>` with their own items. The pill index is captured via `{@const idx}` so item callbacks stay valid regardless of close ordering.

Per the #234 decision, **FieldPicker stays a separate popover** (it's a field/category picker, not a command menu); a later pass can share just the dismissal helper if it proves worthwhile.

## Verification
These context menus aren't covered by e2e, so I verified the interaction directly in the preview on `/pens`:
- Right-click a filter pill → menu opens **at the cursor** (`left/top` = click coords) with the right items (Edit / Disable / Remove).
- Clicking **Disable** toggles the pill disabled **and** closes the menu (confirms the index-capture path).
- **Escape** and **outside-click** both dismiss.
- ColumnBar's dynamic **"Remove all Model"** label resolves from the pill's group.
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · unit + **28 e2e** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
