### PR TITLE
feat(ui): TableFrame chrome + adopt in CompatEntityTable (#229)

### DIFF
--- a/src/lib/components/CompatEntityTable.svelte
+++ b/src/lib/components/CompatEntityTable.svelte
@@ -10,6 +10,7 @@
 	// separately.
 
 	import ExportTableButton from '$lib/components/ExportTableButton.svelte';
+	import TableFrame from '$lib/components/TableFrame.svelte';
 
 	type Cell = string | number | null | undefined;
 
@@ -41,8 +42,8 @@
 	} = $props();
 </script>
 
-{#if rows.length > 0}
-	<div class="table-header">
+<TableFrame isEmpty={rows.length === 0} {emptyMessage}>
+	{#snippet actions()}
 		<ExportTableButton
 			entityType={exportEntityType}
 			title={exportTitle}
@@ -50,7 +51,7 @@
 			headers={exportHeaders}
 			rows={exportRows}
 		/>
-	</div>
+	{/snippet}
 	<table class="compat-table">
 		<thead>
 			<tr>
@@ -73,17 +74,9 @@
 			{/each}
 		</tbody>
 	</table>
-{:else}
-	<p class="no-data">{emptyMessage}</p>
-{/if}
+</TableFrame>
 
 <style>
-	.table-header {
-		display: flex;
-		justify-content: flex-end;
-		margin-bottom: 8px;
-	}
-
 	.compat-table {
 		width: 100%;
 		border-collapse: collapse;
@@ -106,11 +99,5 @@
 	}
 	.compat-table a:hover {
 		text-decoration: underline;
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 </style>

--- a/src/lib/components/TableFrame.svelte
+++ b/src/lib/components/TableFrame.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	// Shared table chrome (GitHub #229). Owns the *chrome* only — an optional
+	// title + count badge + subtitle, a right-aligned table-level actions area
+	// (where export/commands live, so they sit with the table they operate on),
+	// and a consistent empty state. The table body stays a snippet/child so each
+	// caller keeps its own columns/cells (per the #228 ruling: frames standardize
+	// chrome, bodies stay specialized). Composes EmptyState (#237).
+	import type { Snippet } from 'svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
+
+	let {
+		title,
+		count,
+		subtitle,
+		actions,
+		isEmpty = false,
+		emptyMessage = 'No data.',
+		empty,
+		children,
+	}: {
+		title?: string;
+		/** Optional count badge shown next to the title. */
+		count?: number;
+		subtitle?: string;
+		/** Table-level commands (export, etc.), right-aligned in the header. */
+		actions?: Snippet;
+		isEmpty?: boolean;
+		emptyMessage?: string;
+		/** Custom empty content; overrides emptyMessage when provided. */
+		empty?: Snippet;
+		children: Snippet;
+	} = $props();
+
+	// Actions operate on the rows, so hide them when there's nothing to act on
+	// (matches the prior per-table behavior of hiding export on empty).
+	let showActions = $derived(Boolean(actions) && !isEmpty);
+	let hasHeader = $derived(Boolean(title || subtitle || showActions));
+</script>
+
+<div class="table-frame">
+	{#if hasHeader}
+		<div class="tf-header">
+			{#if title}
+				<h3 class="tf-title">
+					{title}{#if count != null}<span class="tf-count">{count}</span>{/if}
+				</h3>
+			{/if}
+			{#if subtitle}<span class="tf-subtitle">{subtitle}</span>{/if}
+			{#if actions}<div class="tf-actions">{@render actions()}</div>{/if}
+		</div>
+	{/if}
+
+	{#if isEmpty}
+		{#if empty}{@render empty()}{:else}<EmptyState>{emptyMessage}</EmptyState>{/if}
+	{:else}
+		{@render children()}
+	{/if}
+</div>
+
+<style>
+	.tf-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 8px;
+	}
+
+	.tf-title {
+		margin: 0;
+		font-size: 14px;
+		font-weight: 600;
+		color: #6b21a8;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.tf-count {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-muted);
+		background: var(--bg-card);
+		border: 1px solid var(--border-light);
+		border-radius: 10px;
+		padding: 0 7px;
+	}
+
+	.tf-subtitle {
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+
+	/* Right-align the actions; works with or without a title present. */
+	.tf-actions {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+</style>


### PR DESCRIPTION
Fifth slice of the UX-architecture epic (#228) — the **first frame**, now that the leaf primitives (#239 / #237 / #238 / #232) are merged. Per the [open-decisions ruling](https://github.com/TheSevenPens/DrawTabDataExplorer/issues/228#issuecomment-4739180954), `TableFrame` standardizes table **chrome only** and leaves the body a snippet (no `SimpleDataTable`/universal body API).

## What's here
- **`TableFrame.svelte`** — optional `title` + `count` badge + `subtitle`, a right-aligned **actions** area (so export/commands sit with the table they operate on — the #229 goal), and a consistent empty state via `EmptyState` (#237). Actions are hidden when `isEmpty` (nothing to act on), matching prior per-table behavior.
- **`CompatEntityTable.svelte`** — adopts `TableFrame`: export → `actions` slot, the empty `.no-data` paragraph → the frame's empty state, table → child. Dead `.table-header` / `.no-data` CSS removed.

`CompatEntityTable` backs three surfaces (PenDetail **Compatible Tablets** + **Included With**, `TabletCompatiblePensTab`, PenFamilyDetail **Members**), so this single change propagates to all of them.

Remaining tables (`DistributionTable`, the data-quality/analysis section tables, the compare matrices) adopt `TableFrame` in follow-ups — keeping this reviewable, per "small PRs, finish/migrate not churn". `EntityExplorer`/`ResultsTable` stay specialized by design.

## Verification
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · **558 unit · 28 e2e**.
- Verified in preview: the populated **Compatible Tablets** tab shows the export button **inside** the table chrome over a 29-row table; the empty **Included With** tab shows the EmptyState message (`rgb(153,153,153)` italic) with **no** export button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
