### PR TITLE
refactor(ui): unify flag controls on FlagButton (#235, #233)

### DIFF
--- a/src/lib/components/FlagButton.svelte
+++ b/src/lib/components/FlagButton.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
+	// Shared flag toggle (GitHub #235). Two visual variants of one control so
+	// every flag affordance — list cells, detail headers, family/unit toggles —
+	// looks and behaves the same: the default bordered icon button (detail
+	// headers) and a borderless `compact` icon (dense table cells).
 	let {
 		flagged,
 		onclick,
 		label = 'Flag for comparison',
-	}: { flagged: boolean; onclick: () => void; label?: string } = $props();
+		compact = false,
+	}: { flagged: boolean; onclick: () => void; label?: string; compact?: boolean } = $props();
 </script>
 
 <button
 	type="button"
 	class="flag-btn"
 	class:on={flagged}
+	class:compact
 	{onclick}
 	title={flagged ? `Unflag (${label})` : label}
 	aria-label={flagged ? `Unflag (${label})` : label}
@@ -41,5 +47,21 @@
 		background: #fff3cd;
 		border-color: #d97706;
 		color: #b45309;
+	}
+
+	/* Borderless minimal icon for dense table cells. */
+	.flag-btn.compact {
+		padding: 0;
+		font-size: 16px;
+		border: none;
+		background: none;
+		color: var(--text-dim);
+	}
+	.flag-btn.compact:hover {
+		color: #d97706;
+	}
+	.flag-btn.compact.on {
+		background: none;
+		color: #d97706;
 	}
 </style>

--- a/src/lib/components/ResultsTable.svelte
+++ b/src/lib/components/ResultsTable.svelte
@@ -4,6 +4,7 @@
 	import type { ResolvedPathname } from '$app/types';
 	import { unitPreference } from '$lib/unit-store.js';
 	import { formatValue, getFieldLabel } from '$data/lib/units.js';
+	import FlagButton from '$lib/components/FlagButton.svelte';
 	import type { CellLinks } from '$lib/table-types.js';
 
 	let {
@@ -96,13 +97,11 @@
 					{#if showFlags}
 						{@const eid = item.Meta?.EntityId ?? item.EntityId ?? item.InventoryId ?? ''}
 						<td class="flag-col">
-							<button
-								class="flag-btn"
-								class:flagged={flaggedIds!.has(eid)}
+							<FlagButton
+								compact
+								flagged={flaggedIds!.has(eid)}
 								onclick={() => onToggleFlag!(eid)}
-								title={flaggedIds!.has(eid) ? 'Unflag' : 'Flag for comparison'}
-								>{flaggedIds!.has(eid) ? '\u2691' : '\u2690'}</button
-							>
+							/>
 						</td>
 					{/if}
 					{#each fieldDefs as f (f.key)}
@@ -177,23 +176,5 @@
 		width: 28px;
 		padding: 0 2px;
 		text-align: center;
-	}
-
-	.flag-btn {
-		background: none;
-		border: none;
-		cursor: pointer;
-		font-size: 16px;
-		color: var(--text-dim);
-		padding: 0;
-		line-height: 1;
-	}
-
-	.flag-btn.flagged {
-		color: #d97706;
-	}
-
-	.flag-btn:hover {
-		color: #d97706;
 	}
 </style>

--- a/src/lib/components/TabletDetail.svelte
+++ b/src/lib/components/TabletDetail.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { brandName, type Tablet, type ISOPaperSize } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
+	import FlagButton from '$lib/components/FlagButton.svelte';
 	import { type Pen } from '$data/lib/entities/pen-fields.js';
 	import { type TabletFamily } from '$data/lib/entities/tablet-family-fields.js';
 	import type { InventoryTablet } from '$data/lib/entities/inventory-tablet-fields.js';
@@ -50,13 +51,11 @@
 
 <div class="title-row">
 	<h1>{tabletFullName(tablet)}</h1>
-	<button
-		class="flag-toggle"
-		class:flagged={$flaggedTablets.includes(tablet.Meta.EntityId)}
+	<FlagButton
+		flagged={$flaggedTablets.includes(tablet.Meta.EntityId)}
 		onclick={() => toggleFlag(tablet.Meta.EntityId)}
-	>
-		{$flaggedTablets.includes(tablet.Meta.EntityId) ? 'Unflag' : 'Flag'}
-	</button>
+		label="Flag this tablet for comparison"
+	/>
 </div>
 
 <section class="basics">
@@ -168,27 +167,6 @@
 
 	h1 {
 		margin: 0;
-	}
-
-	.flag-toggle {
-		padding: 4px 10px;
-		font-size: 13px;
-		border: 1px solid #d97706;
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: #d97706;
-		cursor: pointer;
-		font-weight: 600;
-	}
-
-	.flag-toggle:hover {
-		background: #d97706;
-		color: #fff;
-	}
-
-	.flag-toggle.flagged {
-		background: #d97706;
-		color: #fff;
 	}
 
 	.basics {


### PR DESCRIPTION
Eighth slice of the UX-architecture epic (#228). One concept — "flag this" — was rendered **three** ways: PenDetail/PenFamilyDetail used `<FlagButton>`, **TabletDetail** hand-rolled a `.flag-toggle` *text* button, and **ResultsTable** inlined its own borderless `.flag-btn` icon. This routes all of them through `FlagButton`.

This is the lowest-risk first step of #233 (consistent detail-header actions) and the core of #235's acceptance ("flag controls look and behave consistently across lists, details, pickers") — no new abstraction, just one component with two variants.

## What's here
- **`FlagButton.svelte`** — adds a `compact` variant (borderless minimal icon) for dense table cells, alongside the default bordered icon used in detail headers.
- **`TabletDetail.svelte`** — the `.flag-toggle` *text* button → `<FlagButton>` (now matches PenDetail's bordered icon); dead CSS removed.
- **`ResultsTable.svelte`** — inline `.flag-btn` markup → `<FlagButton compact>`; dead CSS removed.

## Verification
- `npm run check` → 0 errors · `npm run lint` → 0 errors (22 pre-existing warnings) · **558 unit · 28 e2e** (the smoke test flags a tablet from the list, exercising the compact path).
- Verified in preview: `/tablets` list cells render the borderless ⚐→⚑ amber toggle (`aria-pressed` flips, `rgb(217,119,6)`); the TabletDetail header renders the bordered `FlagButton` (`title="Flag this tablet for comparison"`), matching PenDetail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
