### PR TITLE
refactor(ui): adopt EntityLink across detail pages (#238 tail)

### DIFF
--- a/src/lib/components/InventoryPenDetail.svelte
+++ b/src/lib/components/InventoryPenDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import Nav from '$lib/components/Nav.svelte';
 	import DetailView from '$lib/components/DetailView.svelte';
 	import PressureChart from '$lib/components/PressureChart.svelte';
@@ -51,7 +51,7 @@
 <div class="title-row">
 	<h1>{item.InventoryId}</h1>
 	<span class="model-link">
-		<a href={resolve('/entity/[entityId]', { entityId: item.PenEntityId })}>{modelName}</a>
+		<EntityLink entityId={item.PenEntityId}>{modelName}</EntityLink>
 	</span>
 </div>
 
@@ -147,13 +147,6 @@
 	.model-link {
 		font-size: 16px;
 		color: var(--text-muted);
-	}
-	.model-link a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.model-link a:hover {
-		text-decoration: underline;
 	}
 	.tab-content {
 		margin-bottom: 24px;

--- a/src/lib/components/InventoryTabletDetail.svelte
+++ b/src/lib/components/InventoryTabletDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import Nav from '$lib/components/Nav.svelte';
 	import DetailView from '$lib/components/DetailView.svelte';
 	import {
@@ -21,7 +22,7 @@
 <div class="title-row">
 	<h1>{item.InventoryId}</h1>
 	<span class="model-link">
-		<a href={resolve('/entity/[entityId]', { entityId: item.TabletEntityId })}>{modelName}</a>
+		<EntityLink entityId={item.TabletEntityId}>{modelName}</EntityLink>
 	</span>
 </div>
 
@@ -49,9 +50,9 @@
 							<a href={resolve('/pen-inventory/[id]', { id: p._id })}>{p.InventoryId}</a>
 						</td>
 						<td>
-							<a href={resolve('/entity/[entityId]', { entityId: p.PenEntityId })}>
-								{penNameMap.get(p.PenEntityId) ?? p.PenEntityId}
-							</a>
+							<EntityLink entityId={p.PenEntityId}
+								>{penNameMap.get(p.PenEntityId) ?? p.PenEntityId}</EntityLink
+							>
 						</td>
 						<td>{p.Brand}</td>
 					</tr>
@@ -75,13 +76,6 @@
 	.model-link {
 		font-size: 16px;
 		color: var(--text-muted);
-	}
-	.model-link a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.model-link a:hover {
-		text-decoration: underline;
 	}
 	.bundled-section {
 		margin-top: 24px;

--- a/src/lib/components/PenDetail.svelte
+++ b/src/lib/components/PenDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, type Tablet, type PressureResponse } from '$data/lib/drawtab-loader.js';
 	import type { DefectInfo } from '$data/lib/pressure/defects.js';
 	import Nav from '$lib/components/Nav.svelte';
@@ -114,9 +115,7 @@
 		<div class="basics-item">
 			<dt>Brand</dt>
 			<dd>
-				<a href={resolve('/entity/[entityId]', { entityId: pen.Brand.toLowerCase() })}
-					>{brandName(pen.Brand)}</a
-				>
+				<EntityLink entityId={pen.Brand.toLowerCase()}>{brandName(pen.Brand)}</EntityLink>
 			</dd>
 		</div>
 		<div class="basics-item">
@@ -137,9 +136,7 @@
 			<div class="basics-item">
 				<dt>Family</dt>
 				<dd>
-					<a href={resolve('/entity/[entityId]', { entityId: pen.PenFamily })}
-						>{getPenFamilyName(pen.PenFamily)}</a
-					>
+					<EntityLink entityId={pen.PenFamily}>{getPenFamilyName(pen.PenFamily)}</EntityLink>
 				</dd>
 			</div>
 		{/if}
@@ -356,13 +353,6 @@
 	.basics-item dd {
 		font-size: 13px;
 		color: var(--text);
-	}
-	.basics-item dd a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.basics-item dd a:hover {
-		text-decoration: underline;
 	}
 
 	.tab-content {

--- a/src/lib/components/PenFamilyDetail.svelte
+++ b/src/lib/components/PenFamilyDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import type { Pen, PressureResponse } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
 	import {
@@ -113,10 +113,11 @@
 					{#each sortedMemberPens as p (p.EntityId)}
 						<tr>
 							<td>
-								<a href={resolve('/entity/[entityId]', { entityId: p.EntityId })}>
-									{penBrandAndName(p)}
-									{#if !penIdRedundantInName(p)}<span class="dim">({p.PenId})</span>{/if}
-								</a>
+								<EntityLink entityId={p.EntityId}
+									>{penBrandAndName(p)}
+									{#if !penIdRedundantInName(p)}<span class="dim">({p.PenId})</span
+										>{/if}</EntityLink
+								>
 							</td>
 							<td class="year">{p.PenYear || ''}</td>
 						</tr>
@@ -227,13 +228,6 @@
 	}
 	.pen-table tr:hover td {
 		background: var(--hover-bg);
-	}
-	.pen-table a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.pen-table a:hover {
-		text-decoration: underline;
 	}
 	.year {
 		color: var(--text-muted);

--- a/src/lib/components/SessionDetail.svelte
+++ b/src/lib/components/SessionDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { type PressureResponse, type Pen, type Tablet } from '$data/lib/drawtab-loader.js';
 	import { penFullName } from '$lib/pen-helpers.js';
 	import { tabletFullName } from '$lib/tablet-helpers.js';
@@ -112,7 +112,7 @@
 	<dl class="meta">
 		<dt>Pen</dt>
 		<dd>
-			<a href={resolve('/entity/[entityId]', { entityId: session.PenEntityId })}>{penLabel}</a>
+			<EntityLink entityId={session.PenEntityId}>{penLabel}</EntityLink>
 		</dd>
 		<dt>Inventory ID</dt>
 		<dd class="mono">{session.InventoryId}</dd>
@@ -120,9 +120,7 @@
 		<dd class="mono">{session.Date}</dd>
 		<dt>Tablet</dt>
 		<dd>
-			<a href={resolve('/entity/[entityId]', { entityId: session.TabletEntityId })}>
-				{tabletLabel}
-			</a>
+			<EntityLink entityId={session.TabletEntityId}>{tabletLabel}</EntityLink>
 		</dd>
 		<dt>Driver</dt>
 		<dd class="mono">{session.Driver}</dd>

--- a/src/lib/components/TabletDetail.svelte
+++ b/src/lib/components/TabletDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, type Tablet, type ISOPaperSize } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
 	import FlagButton from '$lib/components/FlagButton.svelte';
@@ -63,8 +63,8 @@
 		<div class="basics-item">
 			<dt>Brand</dt>
 			<dd>
-				<a href={resolve('/entity/[entityId]', { entityId: tablet.Model.Brand.toLowerCase() })}
-					>{brandName(tablet.Model.Brand)}</a
+				<EntityLink entityId={tablet.Model.Brand.toLowerCase()}
+					>{brandName(tablet.Model.Brand)}</EntityLink
 				>
 			</dd>
 		</div>
@@ -72,9 +72,7 @@
 			<div class="basics-item">
 				<dt>Family</dt>
 				<dd>
-					<a href={resolve('/entity/[entityId]', { entityId: family.EntityId })}
-						>{family.FamilyName}</a
-					>
+					<EntityLink entityId={family.EntityId}>{family.FamilyName}</EntityLink>
 				</dd>
 			</div>
 		{/if}
@@ -111,7 +109,7 @@
 					{#each includedPenItems as pen, i (pen.entityId)}
 						{#if i > 0},
 						{/if}
-						<a href={resolve('/entity/[entityId]', { entityId: pen.entityId })}>{pen.name}</a>
+						<EntityLink entityId={pen.entityId}>{pen.name}</EntityLink>
 					{/each}
 				</dd>
 			</div>
@@ -204,15 +202,6 @@
 	.basics-item dd {
 		font-size: 13px;
 		color: var(--text);
-	}
-
-	.basics-item dd a {
-		color: var(--link);
-		text-decoration: none;
-	}
-
-	.basics-item dd a:hover {
-		text-decoration: underline;
 	}
 
 	.tab-content {

--- a/src/lib/components/TabletFamilyDetail.svelte
+++ b/src/lib/components/TabletFamilyDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { getDiagonal, type Tablet } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
 	import {
@@ -101,11 +101,7 @@
 					{@const d = tablet.Digitizer?.Dimensions}
 					{@const isPenTablet = tablet.Model.Type === 'PENTABLET'}
 					<tr>
-						<td
-							><a href={resolve('/entity/[entityId]', { entityId: tablet.Meta.EntityId })}
-								>{tablet.Model.Id}</a
-							></td
-						>
+						<td><EntityLink entityId={tablet.Meta.EntityId}>{tablet.Model.Id}</EntityLink></td>
 						<td>{tablet.Model.Name}</td>
 						<td>{(tablet.Model.AlternateNames ?? []).join(', ')}</td>
 						<td>{tablet.Model.Type}</td>
@@ -207,13 +203,6 @@
 	}
 	tr:hover td {
 		background: #f0f7ff;
-	}
-	td a {
-		color: #2563eb;
-		text-decoration: none;
-	}
-	td a:hover {
-		text-decoration: underline;
 	}
 	.no-data {
 		font-size: 13px;

--- a/src/lib/components/tablet-detail/TabletSimilarTab.svelte
+++ b/src/lib/components/tablet-detail/TabletSimilarTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, getDiagonal, type Tablet } from '$data/lib/drawtab-loader.js';
 	import { findSimilarTablets } from '$data/lib/compat-helpers.js';
 	import ExportTableButton from '$lib/components/ExportTableButton.svelte';
@@ -142,11 +142,7 @@
 				{@const px = t.Display?.PixelDimensions}
 				{@const pxDensity = px && d && px.Width && d.Width ? (px.Width / d.Width).toFixed(2) : ''}
 				<tr>
-					<td
-						><a href={resolve('/entity/[entityId]', { entityId: t.Meta.EntityId })}
-							>{tabletFullName(t)}</a
-						></td
-					>
+					<td><EntityLink entityId={t.Meta.EntityId}>{tabletFullName(t)}</EntityLink></td>
 					<td>{t.Model.LaunchYear || ''}</td>
 					<td>{d ? `${d.Width} x ${d.Height} mm` : ''}</td>
 					<td>{diag ? `${diag.toFixed(1)} mm` : ''}</td>
@@ -220,15 +216,6 @@
 
 	.similar-table tr:hover td {
 		background: var(--hover-bg);
-	}
-
-	.similar-table a {
-		color: var(--link);
-		text-decoration: none;
-	}
-
-	.similar-table a:hover {
-		text-decoration: underline;
 	}
 
 	.no-data {


### PR DESCRIPTION
Continues the #238 EntityLink adoption (after the BrandDetail/TabletModelTab pilot in #243). Converts the remaining inline `<a href={resolve('/entity/[entityId]', …)}>` **markup** links across the detail pages to `<EntityLink>`, and removes the now-dead per-file link CSS that `EntityLink` now owns.

**Files (13 anchor sites):** InventoryPenDetail, InventoryTabletDetail, PenDetail, PenFamilyDetail, SessionDetail, TabletDetail, TabletFamilyDetail, tablet-detail/TabletSimilarTab.

Data-shaped links (`href: resolve(...)` feeding `ResultsTable`/`CompatEntityTable`) are intentionally left as-is per #238 — `EntityLink` is for markup `<a>`. The chart-companion legends (`PressureRangeTab`, `PressureResponseChartLegendTable`) are a separate follow-up.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: PenDetail brand + family links resolve to the right `/entity` URLs at `rgb(37,99,235)`.

> ⚠️ **Stacked on `ux/231-sectionheader` (PR #249)** — merge #249 first; GitHub will retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
