### PR TITLE
refactor(ui): adopt EntityLink in chart-companion legends (#238 tail)

### DIFF
--- a/src/lib/components/PressureRangeTab.svelte
+++ b/src/lib/components/PressureRangeTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import BandsChart, { type BandMarker } from '$lib/components/BandsChart.svelte';
 	import { PIAF_BANDS, PMAX_BANDS } from '$lib/bands.js';
 	import type { PressureResponse, PressureRange } from '$data/lib/drawtab-loader.js';
@@ -290,9 +290,7 @@
 						<tr>
 							{#if showPenColumn}
 								<td>
-									<a href={resolve('/entity/[entityId]', { entityId: r.penEntityId })}>
-										{penName(r.penEntityId)}
-									</a>
+									<EntityLink entityId={r.penEntityId}>{penName(r.penEntityId)}</EntityLink>
 								</td>
 							{/if}
 							<td class="mono">{r.inventoryId}</td>
@@ -343,34 +341,27 @@
 						<tr>
 							{#if showPenColumn}
 								<td>
-									<a href={resolve('/entity/[entityId]', { entityId: s.penEntityId })}>
-										{penName(s.penEntityId)}
-									</a>
+									<EntityLink entityId={s.penEntityId}>{penName(s.penEntityId)}</EntityLink>
 								</td>
 							{/if}
 							<td class="mono">
 								{#if s.sessionEntityId}
-									<a href={resolve('/entity/[entityId]', { entityId: s.sessionEntityId })}
-										>{s.inventoryId}</a
-									>
+									<EntityLink entityId={s.sessionEntityId}>{s.inventoryId}</EntityLink>
 								{:else}
 									{s.inventoryId}
 								{/if}
 							</td>
 							<td class="mono">
 								{#if s.sessionEntityId}
-									<a href={resolve('/entity/[entityId]', { entityId: s.sessionEntityId })}
-										>{s.date}</a
-									>
+									<EntityLink entityId={s.sessionEntityId}>{s.date}</EntityLink>
 								{:else}
 									{s.date}
 								{/if}
 							</td>
 							<td>
 								{#if s.tabletEntityId}
-									<a href={resolve('/entity/[entityId]', { entityId: s.tabletEntityId })}>
-										{tabletName(s.tabletEntityId)}
-									</a>
+									<EntityLink entityId={s.tabletEntityId}>{tabletName(s.tabletEntityId)}</EntityLink
+									>
 								{/if}
 							</td>
 							<td class="mono">{s.driver}</td>
@@ -526,13 +517,6 @@
 	}
 	.range-table tr:hover td {
 		background: var(--hover-bg);
-	}
-	.range-table a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.range-table a:hover {
-		text-decoration: underline;
 	}
 	.mono {
 		font-family: ui-monospace, 'Cascadia Mono', Menlo, monospace;

--- a/src/lib/components/PressureResponseChartLegendTable.svelte
+++ b/src/lib/components/PressureResponseChartLegendTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, type PressureResponse } from '$data/lib/drawtab-loader.js';
 	import {
 		estimatePiaf,
@@ -112,26 +112,23 @@
 					{/if}
 					{#if showModel}
 						<td>
-							<a href={resolve('/entity/[entityId]', { entityId: r.session.PenEntityId })}>
-								{penNameById.get(r.session.PenEntityId) ?? r.session.PenEntityId}
-							</a>
+							<EntityLink entityId={r.session.PenEntityId}
+								>{penNameById.get(r.session.PenEntityId) ?? r.session.PenEntityId}</EntityLink
+							>
 						</td>
 					{/if}
 					<td class="mono">
-						<a href={resolve('/entity/[entityId]', { entityId: sessionEntityId(r.session) })}>
-							{r.session.InventoryId}
-						</a>
+						<EntityLink entityId={sessionEntityId(r.session)}>{r.session.InventoryId}</EntityLink>
 					</td>
 					<td class="mono">
-						<a href={resolve('/entity/[entityId]', { entityId: sessionEntityId(r.session) })}>
-							{r.session.Date}
-						</a>
+						<EntityLink entityId={sessionEntityId(r.session)}>{r.session.Date}</EntityLink>
 					</td>
 					<td>
 						{#if r.session.TabletEntityId}
-							<a href={resolve('/entity/[entityId]', { entityId: r.session.TabletEntityId })}>
-								{tabletNameById.get(r.session.TabletEntityId) ?? r.session.TabletEntityId}
-							</a>
+							<EntityLink entityId={r.session.TabletEntityId}
+								>{tabletNameById.get(r.session.TabletEntityId) ??
+									r.session.TabletEntityId}</EntityLink
+							>
 						{/if}
 					</td>
 					<td class="mono">{r.session.Driver}</td>
@@ -205,12 +202,5 @@
 		color: #d97706;
 		font-weight: 700;
 		cursor: help;
-	}
-	a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	a:hover {
-		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
Final **#238** EntityLink adoption slice (after the component pilot #243 and the detail-page tail #250). Converts the remaining inline `<a href={resolve('/entity/[entityId]', …)}>` markup links in the chart/legend tables and removes the now-dead per-file link CSS.

- **`PressureRangeTab.svelte`** — 5 anchors (pen / session / tablet links in the By-unit and By-sample rank tables).
- **`PressureResponseChartLegendTable.svelte`** — 4 anchors (pen / session / tablet legend links).

This **completes #238**: every markup `/entity/[entityId]` link now routes through `EntityLink`; data-shaped links (`cellLinks`) stay in code by design.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: the PenDetail IAF tab "By sample" table renders the EntityLink rows (→ `/entity/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
