### PR TITLE
refactor(ui): adopt EmptyState across remaining empty states (#237 tail)

### DIFF
--- a/src/lib/components/BrandDetail.svelte
+++ b/src/lib/components/BrandDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { type Brand, BRAND_FIELDS, BRAND_FIELD_GROUPS } from '$data/lib/entities/brand-fields.js';
 	import { type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
@@ -100,7 +101,7 @@
 					</tbody>
 				</table>
 			{:else}
-				<p class="no-data">No tablets found for this brand.</p>
+				<EmptyState>No tablets found for this brand.</EmptyState>
 			{/if}
 		{:else if activeTab === 'pens'}
 			{#if sortedPens.length > 0}
@@ -132,11 +133,11 @@
 					</tbody>
 				</table>
 			{:else}
-				<p class="no-data">No pens found for this brand.</p>
+				<EmptyState>No pens found for this brand.</EmptyState>
 			{/if}
 		{:else if activeTab === 'timeline'}
 			{#if timeline.length === 0}
-				<p class="no-data">No timeline data available.</p>
+				<EmptyState>No timeline data available.</EmptyState>
 			{:else}
 				<div class="brand-timeline">
 					{#each timeline as entry (entry.year)}
@@ -223,12 +224,6 @@
 	td {
 		padding: 5px 10px;
 		border-bottom: 1px solid var(--border);
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: #999;
-		font-style: italic;
 	}
 
 	.brand-timeline {

--- a/src/lib/components/ForceProportionsView.svelte
+++ b/src/lib/components/ForceProportionsView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { POPULAR_RATIOS, VERYCLOSE_THRESHOLD } from '$data/lib/aspect-ratio.js';
 	import { unitPreference } from '$lib/unit-store.js';
 	import { MM_TO_IN } from '$lib/tablet-size-ranges.js';
@@ -130,7 +131,7 @@
 </script>
 
 {#if calcs.length === 0}
-	<p class="no-data">Active area dimensions are missing for this tablet.</p>
+	<EmptyState>Active area dimensions are missing for this tablet.</EmptyState>
 {:else}
 	<div class="intro">
 		<p>
@@ -401,10 +402,5 @@
 	}
 	.swatch.lost {
 		background: #bfe5f5;
-	}
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 </style>

--- a/src/lib/components/InventoryPenDetail.svelte
+++ b/src/lib/components/InventoryPenDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import Nav from '$lib/components/Nav.svelte';
 	import DetailView from '$lib/components/DetailView.svelte';
@@ -96,7 +97,7 @@
 				{defectsByInventoryId}
 			/>
 		{:else}
-			<p class="no-data">No pressure response sessions recorded for this pen unit.</p>
+			<EmptyState>No pressure response sessions recorded for this pen unit.</EmptyState>
 		{/if}
 	</div>
 {/if}
@@ -157,10 +158,5 @@
 	}
 	.tab-content {
 		margin-bottom: 24px;
-	}
-	.no-data {
-		font-size: 13px;
-		color: var(--text-muted);
-		font-style: italic;
 	}
 </style>

--- a/src/lib/components/PressureRangeTab.svelte
+++ b/src/lib/components/PressureRangeTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import EntityLink from '$lib/components/EntityLink.svelte';
 	import BandsChart, { type BandMarker } from '$lib/components/BandsChart.svelte';
 	import { PIAF_BANDS, PMAX_BANDS } from '$lib/bands.js';
@@ -380,16 +381,10 @@
 		</div>
 	{/if}
 {:else}
-	<p class="no-data">No {metric} data available for {entityLabel}.</p>
+	<EmptyState>No {metric} data available for {entityLabel}.</EmptyState>
 {/if}
 
 <style>
-	.no-data {
-		font-size: 13px;
-		color: var(--text-muted);
-		font-style: italic;
-	}
-
 	.view-toggle {
 		display: inline-flex;
 		gap: 0;

--- a/src/lib/components/TabletFamilyDetail.svelte
+++ b/src/lib/components/TabletFamilyDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { getDiagonal, type Tablet } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
@@ -140,7 +141,7 @@
 			</tbody>
 		</table>
 	{:else}
-		<p class="no-data">No tablets found in this family.</p>
+		<EmptyState>No tablets found in this family.</EmptyState>
 	{/if}
 </section>
 
@@ -214,11 +215,6 @@
 	}
 	td a:hover {
 		text-decoration: underline;
-	}
-	.no-data {
-		font-size: 13px;
-		color: #999;
-		font-style: italic;
 	}
 
 	.dim-chart-section {

--- a/src/lib/components/tablet-detail/TabletInventoryTab.svelte
+++ b/src/lib/components/tablet-detail/TabletInventoryTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import type { InventoryTablet } from '$data/lib/entities/inventory-tablet-fields.js';
 
@@ -27,7 +28,7 @@
 		</tbody>
 	</table>
 {:else}
-	<p class="no-data">You don't own a unit of this tablet model.</p>
+	<EmptyState>You don't own a unit of this tablet model.</EmptyState>
 {/if}
 
 <style>
@@ -53,11 +54,5 @@
 	}
 	.compat-table a:hover {
 		text-decoration: underline;
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 </style>

--- a/src/lib/components/tablet-detail/TabletSimilarTab.svelte
+++ b/src/lib/components/tablet-detail/TabletSimilarTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { brandName, getDiagonal, type Tablet } from '$data/lib/drawtab-loader.js';
 	import { findSimilarTablets } from '$data/lib/compat-helpers.js';
@@ -161,7 +162,7 @@
 		</tbody>
 	</table>
 {:else}
-	<p class="no-data">No matching tablets found. Try adjusting the filters.</p>
+	<EmptyState>No matching tablets found. Try adjusting the filters.</EmptyState>
 {/if}
 
 <style>
@@ -229,11 +230,5 @@
 
 	.similar-table a:hover {
 		text-decoration: underline;
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 </style>

--- a/src/lib/pen-analysis/PressureMetricSection.svelte
+++ b/src/lib/pen-analysis/PressureMetricSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import ValueHistogram from '$lib/components/ValueHistogram.svelte';
 	import DistributionTable from '$lib/components/DistributionTable.svelte';
 	import AnalysisExportRow from '$lib/tablet-analysis/AnalysisExportRow.svelte';
@@ -151,7 +152,7 @@
 	<AnalysisExportRow onclick={onExport} />
 	<DistributionTable labelHeader="Band" rows={bandRows} total={rows.length} />
 {:else}
-	<p class="no-data">No measurements available.</p>
+	<EmptyState>No measurements available.</EmptyState>
 {/if}
 
 <style>
@@ -159,11 +160,6 @@
 		font-size: 13px;
 		color: var(--text-dim);
 		margin-bottom: 8px;
-	}
-	.no-data {
-		font-size: 13px;
-		color: var(--text-muted);
-		font-style: italic;
 	}
 
 	.stat-tables {

--- a/src/routes/pen-analysis/+page.svelte
+++ b/src/routes/pen-analysis/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import ChromeLayout from '$lib/components/ChromeLayout.svelte';
 	import ExportDialog from '$lib/components/ExportDialog.svelte';
@@ -314,7 +315,7 @@
 
 {#snippet rankTable(p: RankTableProps)}
 	{#if p.rows.length === 0}
-		<p class="no-data">No measurements available.</p>
+		<EmptyState>No measurements available.</EmptyState>
 	{:else}
 		<div class="rank-controls">
 			<div class="controls-left">
@@ -612,7 +613,7 @@
 						tablets.
 					</p>
 					{#if udemrPens.length === 0}
-						<p class="no-data">No pens tagged UDEMR.</p>
+						<EmptyState>No pens tagged UDEMR.</EmptyState>
 					{:else}
 						<div class="rank-controls">
 							<span class="ud-count">{penCountLabel(udemrPens.length)}</span>
@@ -690,11 +691,6 @@
 		font-size: 13px;
 		color: var(--text-dim);
 		margin-bottom: 8px;
-	}
-	.no-data {
-		font-size: 13px;
-		color: var(--text-muted);
-		font-style: italic;
 	}
 	.rank-controls {
 		display: flex;

--- a/src/routes/pen-compare/+page.svelte
+++ b/src/routes/pen-compare/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	// Pen analog of /tablet-compare. Two tabs:
 	//   Flagged — list of flagged pen models with add/remove affordances
 	//   Compare — grouped spec-comparison table (mirrors the tablets one)
@@ -537,7 +538,7 @@
 					>
 				</h2>
 				{#if section.sessions.length === 0 && section.iaf.length === 0}
-					<p class="no-data">No IAF data for this pen model.</p>
+					<EmptyState>No IAF data for this pen model.</EmptyState>
 				{:else}
 					<PressureRangeTab
 						metric="IAF"
@@ -655,7 +656,7 @@
 					>
 				</h2>
 				{#if section.sessions.length === 0 && section.max.length === 0}
-					<p class="no-data">No MAX data for this pen model.</p>
+					<EmptyState>No MAX data for this pen model.</EmptyState>
 				{:else}
 					<PressureRangeTab
 						metric="MAX"

--- a/src/routes/reference/+page.svelte
+++ b/src/routes/reference/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LoadingState from '$lib/components/LoadingState.svelte';
 	import {
 		penTabletRangesCm,
 		penTabletRangesIn,
@@ -317,7 +318,7 @@
 							</tbody>
 						</table>
 					{:else}
-						<p class="no-data">Loading...</p>
+						<LoadingState />
 					{/if}
 				</section>
 			{/snippet}
@@ -649,12 +650,6 @@
 		font-weight: 600;
 		color: var(--th-text);
 		background: var(--th-bg);
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
 	}
 
 	.ref-blurb {


### PR DESCRIPTION
Continues **#237** adoption. Converts the single-line `<p class="no-data">…</p>` empty states across detail/analysis/compare/reference to `<EmptyState>` and removes the now-dead per-file `.no-data` CSS.

- **15 sites:** BrandDetail, ForceProportionsView, InventoryPenDetail, PressureRangeTab, TabletInventoryTab, TabletSimilarTab, TabletFamilyDetail, PressureMetricSection, `/pen-analysis`, `/pen-compare`.
- **`/reference`:** the mislabeled `<p class="no-data">Loading...</p>` → `<LoadingState />`.

**Scope:** the multi-line empty *workflow* blocks with calls-to-action (`/pen-compare`, `/tablet-compare`, `/pen-flagged`) and the `.empty` blocks in `/pressure-backfill` are a follow-up — those want `EmptyState`'s `action` slot and need per-case judgment.

**Verification:** check 0 · lint 0 (the 10 now-dead `.no-data` selectors removed) · 558 unit · 28 e2e. `EmptyState` itself was verified in #237; these are identical conversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
