### PR TITLE
refactor(ui): shared export-dialog host for the Data routes (#236)

### DIFF
--- a/src/lib/export-dialog-host.svelte.ts
+++ b/src/lib/export-dialog-host.svelte.ts
@@ -1,0 +1,28 @@
+// Shared host for the single per-page ExportDialog (GitHub #236). The Data
+// routes (/data-quality, /reference, /tablet-analysis, /pen-analysis) each
+// declared an identical `exportDialog` $state + `openExport()` setter +
+// "{#if exportDialog} <ExportDialog .../>" mount. This factory owns that
+// state once; a route calls `host.open(...)` from its section triggers and
+// mounts `<ExportDialog ...host.config onclose={host.close} />`.
+
+export interface ExportDialogConfig {
+	title: string;
+	filename: string;
+	headers: string[];
+	rows: (string | number)[][];
+}
+
+export function createExportDialogHost() {
+	let config = $state<ExportDialogConfig | null>(null);
+	return {
+		get config() {
+			return config;
+		},
+		open(title: string, filename: string, headers: string[], rows: (string | number)[][]) {
+			config = { title, filename, headers, rows };
+		},
+		close() {
+			config = null;
+		},
+	};
+}

--- a/src/routes/data-quality/+page.svelte
+++ b/src/routes/data-quality/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createExportDialogHost } from '$lib/export-dialog-host.svelte.js';
 	import { resolve } from '$app/paths';
 	import { sessionEntityId } from '$data/lib/pressure/session-id.js';
 	import ChromeLayout from '$lib/components/ChromeLayout.svelte';
@@ -15,24 +16,11 @@
 
 	let { data } = $props();
 
-	// Single shared ExportDialog instance, opened by per-section trigger
-	// buttons. Each trigger sets `exportDialog` to a config object; the
-	// dialog mounts when set and closes by setting it back to null.
-	let exportDialog: {
-		title: string;
-		filename: string;
-		headers: string[];
-		rows: (string | number)[][];
-	} | null = $state(null);
-
-	function openExport(
-		title: string,
-		filename: string,
-		headers: string[],
-		rows: (string | number)[][],
-	): void {
-		exportDialog = { title, filename, headers, rows };
-	}
+	// Single shared ExportDialog, opened by per-section trigger buttons via the
+	// shared export host (#236). `openExport` is kept as a local alias so the
+	// section triggers read unchanged.
+	const exportHost = createExportDialogHost();
+	const openExport = exportHost.open;
 
 	const analysis = $derived(analyzeData(data));
 
@@ -847,14 +835,14 @@
 			{/snippet}
 		</SectionedPage>
 
-		{#if exportDialog}
+		{#if exportHost.config}
 			<ExportDialog
 				entityType="data-quality"
-				title={exportDialog.title}
-				filename={exportDialog.filename}
-				headers={exportDialog.headers}
-				rows={exportDialog.rows}
-				onclose={() => (exportDialog = null)}
+				title={exportHost.config.title}
+				filename={exportHost.config.filename}
+				headers={exportHost.config.headers}
+				rows={exportHost.config.rows}
+				onclose={exportHost.close}
 			/>
 		{/if}
 	{/if}

--- a/src/routes/pen-analysis/+page.svelte
+++ b/src/routes/pen-analysis/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createExportDialogHost } from '$lib/export-dialog-host.svelte.js';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import ChromeLayout from '$lib/components/ChromeLayout.svelte';
@@ -296,21 +297,8 @@
 		{ id: 'ud-emr', category: 'Tags', label: 'UD EMR' },
 	];
 
-	let exportDialog: {
-		title: string;
-		filename: string;
-		headers: string[];
-		rows: (string | number)[][];
-	} | null = $state(null);
-
-	function openExport(
-		title: string,
-		filename: string,
-		headers: string[],
-		rows: (string | number)[][],
-	): void {
-		exportDialog = { title, filename, headers, rows };
-	}
+	const exportHost = createExportDialogHost();
+	const openExport = exportHost.open;
 </script>
 
 {#snippet rankTable(p: RankTableProps)}
@@ -660,14 +648,14 @@
 		{/snippet}
 	</SectionedPage>
 
-	{#if exportDialog}
+	{#if exportHost.config}
 		<ExportDialog
 			entityType="pen-analysis"
-			title={exportDialog.title}
-			filename={exportDialog.filename}
-			headers={exportDialog.headers}
-			rows={exportDialog.rows}
-			onclose={() => (exportDialog = null)}
+			title={exportHost.config.title}
+			filename={exportHost.config.filename}
+			headers={exportHost.config.headers}
+			rows={exportHost.config.rows}
+			onclose={exportHost.close}
 		/>
 	{/if}
 </ChromeLayout>

--- a/src/routes/reference/+page.svelte
+++ b/src/routes/reference/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createExportDialogHost } from '$lib/export-dialog-host.svelte.js';
 	import LoadingState from '$lib/components/LoadingState.svelte';
 	import {
 		penTabletRangesCm,
@@ -156,23 +157,10 @@
 		}, {}),
 	);
 
-	// Single shared ExportDialog. Each section's Export trigger sets
-	// `exportDialog` to a config object; the dialog mounts when set.
-	let exportDialog: {
-		title: string;
-		filename: string;
-		headers: string[];
-		rows: (string | number)[][];
-	} | null = $state(null);
-
-	function openExport(
-		title: string,
-		filename: string,
-		headers: string[],
-		rows: (string | number)[][],
-	): void {
-		exportDialog = { title, filename, headers, rows };
-	}
+	// Single shared ExportDialog via the shared export host (#236);
+	// `openExport` is a local alias so the section triggers read unchanged.
+	const exportHost = createExportDialogHost();
+	const openExport = exportHost.open;
 </script>
 
 <ChromeLayout subNavTabs={dataTabs}>
@@ -565,14 +553,14 @@
 		{/snippet}
 	</SectionedPage>
 
-	{#if exportDialog}
+	{#if exportHost.config}
 		<ExportDialog
 			entityType="reference"
-			title={exportDialog.title}
-			filename={exportDialog.filename}
-			headers={exportDialog.headers}
-			rows={exportDialog.rows}
-			onclose={() => (exportDialog = null)}
+			title={exportHost.config.title}
+			filename={exportHost.config.filename}
+			headers={exportHost.config.headers}
+			rows={exportHost.config.rows}
+			onclose={exportHost.close}
 		/>
 	{/if}
 </ChromeLayout>

--- a/src/routes/tablet-analysis/+page.svelte
+++ b/src/routes/tablet-analysis/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createExportDialogHost } from '$lib/export-dialog-host.svelte.js';
 	import ChromeLayout from '$lib/components/ChromeLayout.svelte';
 	import ExportDialog from '$lib/components/ExportDialog.svelte';
 	import SectionedPage, { type Section } from '$lib/components/SectionedPage.svelte';
@@ -144,21 +145,8 @@
 
 	// --- Export dialog (shared) ---
 
-	let exportDialog: {
-		title: string;
-		filename: string;
-		headers: string[];
-		rows: (string | number)[][];
-	} | null = $state(null);
-
-	function openExport(
-		title: string,
-		filename: string,
-		headers: string[],
-		rows: (string | number)[][],
-	): void {
-		exportDialog = { title, filename, headers, rows };
-	}
+	const exportHost = createExportDialogHost();
+	const openExport = exportHost.open;
 
 	// --- Sizes ---
 
@@ -393,14 +381,14 @@
 		{/snippet}
 	</SectionedPage>
 
-	{#if exportDialog}
+	{#if exportHost.config}
 		<ExportDialog
 			entityType="analysis"
-			title={exportDialog.title}
-			filename={exportDialog.filename}
-			headers={exportDialog.headers}
-			rows={exportDialog.rows}
-			onclose={() => (exportDialog = null)}
+			title={exportHost.config.title}
+			filename={exportHost.config.filename}
+			headers={exportHost.config.headers}
+			rows={exportHost.config.rows}
+			onclose={exportHost.close}
 		/>
 	{/if}
 </ChromeLayout>


### PR DESCRIPTION
**#236.** `/data-quality`, `/reference`, `/tablet-analysis`, `/pen-analysis` each declared an **identical** `exportDialog` `$state` + `openExport()` setter + `{#if exportDialog} <ExportDialog .../>` mount. This extracts that into one `createExportDialogHost()` rune factory (`src/lib/export-dialog-host.svelte.ts`) and adopts it in all four routes.

Each route keeps a `const openExport = exportHost.open` alias, so the **36 section-trigger call sites read unchanged** — only the state/setter block and the dialog mount move to `exportHost.config` / `exportHost.close`. Minimal churn, single source of the export-dialog state.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: a data-quality section **Export** opens the dialog via the host, **Escape** closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
