### PR TITLE
refactor(ui): route action buttons onto Button (#239 tail)

### DIFF
--- a/src/lib/tablet-analysis/AnalysisExportRow.svelte
+++ b/src/lib/tablet-analysis/AnalysisExportRow.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Button from '$lib/components/Button.svelte';
+
 	let {
 		disabled = false,
 		onclick,
@@ -9,7 +11,7 @@
 </script>
 
 <div class="table-export">
-	<button class="export-trigger" {disabled} {onclick}>Export</button>
+	<Button variant="subtle" {disabled} {onclick}>Export</Button>
 </div>
 
 <style>
@@ -17,26 +19,5 @@
 		display: flex;
 		justify-content: flex-end;
 		margin-bottom: 4px;
-	}
-
-	.export-trigger {
-		display: inline-flex;
-		align-items: center;
-		gap: 5px;
-		padding: 4px 10px;
-		font-size: 12px;
-		border: 1px solid var(--border);
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		cursor: pointer;
-	}
-	.export-trigger:hover {
-		border-color: var(--text-dim);
-		color: var(--text);
-	}
-	.export-trigger:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
 	}
 </style>

--- a/src/routes/pen-compare/+page.svelte
+++ b/src/routes/pen-compare/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import EmptyState from '$lib/components/EmptyState.svelte';
+	import Button from '$lib/components/Button.svelte';
 	// Pen analog of /tablet-compare. Two tabs:
 	//   Flagged — list of flagged pen models with add/remove affordances
 	//   Compare — grouped spec-comparison table (mirrors the tablets one)
@@ -394,8 +395,8 @@
 	<div class="flagged-actions">
 		<button class="add-pen-btn" onclick={() => (showPicker = true)}>+ Add pen</button>
 		{#if flaggedItems.length > 0}
-			<button class="copy-btn" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</button>
-			<button class="clear-btn" onclick={clearFlaggedPenModels}>Clear all</button>
+			<Button variant="subtle" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</Button>
+			<Button variant="danger" onclick={clearFlaggedPenModels}>Clear all</Button>
 		{/if}
 	</div>
 	{#if flaggedItems.length > 0}
@@ -425,10 +426,10 @@
 		</p>
 	{:else}
 		<div class="compare-toolbar">
-			<button
-				class="copy-btn"
+			<Button
+				variant="subtle"
 				onclick={() => (showExport = true)}
-				disabled={compareExportRows.length === 0}>Export</button
+				disabled={compareExportRows.length === 0}>Export</Button
 			>
 		</div>
 		<div class="compare-wrap">
@@ -718,21 +719,6 @@
 		border-color: #1d4ed8;
 	}
 
-	.clear-btn {
-		padding: 4px 12px;
-		font-size: 13px;
-		border: 1px solid #dc2626;
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: #dc2626;
-		cursor: pointer;
-	}
-
-	.clear-btn:hover:not(:disabled) {
-		background: #dc2626;
-		color: #fff;
-	}
-
 	.flagged-list {
 		list-style: none;
 		padding: 0;
@@ -773,21 +759,6 @@
 		display: flex;
 		gap: 8px;
 		margin-bottom: 12px;
-	}
-
-	.copy-btn {
-		padding: 4px 12px;
-		font-size: 12px;
-		border: 1px solid var(--border);
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		cursor: pointer;
-	}
-
-	.copy-btn:hover {
-		background: var(--hover-bg);
-		color: var(--text);
 	}
 
 	.compare-wrap {

--- a/src/routes/pen-flagged/+page.svelte
+++ b/src/routes/pen-flagged/+page.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { brandName, type Pen, type PenFamily } from '$data/lib/drawtab-loader.js';
 	import { penIdRedundantInName } from '$data/lib/entities/pen-fields.js';
+	import Button from '$lib/components/Button.svelte';
 	import { penBrandAndName } from '$lib/pen-helpers.js';
 	import {
 		flaggedPenUnits,
@@ -82,7 +83,7 @@
 		<a href={resolve('/pen-compare')}>Pens ▸ Compare ▸ Pressure Response</a>.
 	</p>
 	{#if $flaggedPenTotalCount > 0}
-		<button class="clear-btn" onclick={clearAllPenFlags}>Clear all flags</button>
+		<Button variant="danger" onclick={clearAllPenFlags}>Clear all flags</Button>
 	{/if}
 </div>
 
@@ -167,20 +168,6 @@
 		margin: 0;
 		color: var(--text-muted);
 		font-size: 13px;
-	}
-	.clear-btn {
-		margin-top: 8px;
-		padding: 4px 12px;
-		font-size: 13px;
-		border: 1px solid var(--border);
-		background: var(--bg-card);
-		color: var(--text-muted);
-		border-radius: 4px;
-		cursor: pointer;
-	}
-	.clear-btn:hover {
-		border-color: #b91c1c;
-		color: #b91c1c;
 	}
 	.empty {
 		margin: 24px 0;

--- a/src/routes/tablet-compare/+page.svelte
+++ b/src/routes/tablet-compare/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { getDiagonal, type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
+	import Button from '$lib/components/Button.svelte';
 	import ValueHistogram, { type HistogramMarker } from '$lib/components/ValueHistogram.svelte';
 	import { TABLET_FIELDS, TABLET_FIELD_GROUPS } from '$data/lib/entities/tablet-fields.js';
 	import { unitPreference } from '$lib/unit-store.js';
@@ -216,9 +217,9 @@
 			>+ Add tablet</button
 		>
 		{#if flaggedItems.length > 0}
-			<button class="copy-btn" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</button>
+			<Button variant="subtle" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</Button>
 		{/if}
-		<button class="clear-btn" onclick={clearFlags}>Clear all</button>
+		<Button variant="danger" onclick={clearFlags}>Clear all</Button>
 	</div>
 	{#if flaggedItems.length > 0}
 		<ul class="flagged-list">
@@ -247,10 +248,10 @@
 		</p>
 	{:else}
 		<div class="compare-toolbar">
-			<button
-				class="copy-btn"
+			<Button
+				variant="subtle"
 				onclick={() => (showExport = true)}
-				disabled={compareExportRows.length === 0}>Export</button
+				disabled={compareExportRows.length === 0}>Export</Button
 			>
 		</div>
 		<div class="compare-wrap">
@@ -486,21 +487,6 @@
 		cursor: default;
 	}
 
-	.clear-btn {
-		padding: 4px 12px;
-		font-size: 13px;
-		border: 1px solid #dc2626;
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: #dc2626;
-		cursor: pointer;
-	}
-
-	.clear-btn:hover:not(:disabled) {
-		background: #dc2626;
-		color: #fff;
-	}
-
 	.flagged-list {
 		list-style: none;
 		padding: 0;
@@ -541,21 +527,6 @@
 		display: flex;
 		gap: 8px;
 		margin-bottom: 12px;
-	}
-
-	.copy-btn {
-		padding: 4px 12px;
-		font-size: 12px;
-		border: 1px solid var(--border);
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		cursor: pointer;
-	}
-
-	.copy-btn:hover {
-		background: var(--hover-bg);
-		color: var(--text);
 	}
 
 	.compare-wrap {


### PR DESCRIPTION
Continues **#239** adoption — replaces one-off `.copy-btn` / `.clear-btn` / `.export-trigger` styles on action buttons with the shared `Button`:

- **`AnalysisExportRow.svelte`** — `.export-trigger` → `<Button variant="subtle">` (one component → every tablet/pen-analysis section export button updates).
- **`/pen-compare`, `/tablet-compare`** — flagged-list **Copy list** → `subtle`, **Clear all** → `danger`, compare **Export** → `subtle`.
- **`/pen-flagged`** — **Clear all flags** → `danger`.

Dead `.copy-btn`/`.clear-btn`/`.export-trigger` CSS removed.

**Follow-up (left for a later PR):** `/reference`'s in-snippet export buttons, `SearchBar`'s clear, the picker/query-bar `+` add buttons, and `ChartExportButton`'s trigger (stays specialized per #236).

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: tablet-compare "Clear all" renders as the `danger` Button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
