### PR TITLE
feat(ui): DetailPageFrame header + pilot on Pen/Tablet detail (#233)

### DIFF
--- a/src/lib/components/DetailPageFrame.svelte
+++ b/src/lib/components/DetailPageFrame.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	// Shared entity-detail page header (GitHub #233). Owns the top chrome every
+	// detail page repeats: <Nav/> + a title row with an optional right-aligned
+	// actions area (flag / copy / export). The page body (DetailView, Tabs, etc.)
+	// stays a sibling after this component — deliberately NOT wrapped as children,
+	// so each detail page keeps its own structure and we avoid nesting its
+	// top-level snippets.
+	import type { Snippet } from 'svelte';
+	import Nav from '$lib/components/Nav.svelte';
+
+	let { title, actions }: { title: string; actions?: Snippet } = $props();
+</script>
+
+<Nav />
+
+<div class="detail-header">
+	<h1>{title}</h1>
+	{#if actions}{@render actions()}{/if}
+</div>
+
+<style>
+	.detail-header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-bottom: 16px;
+	}
+
+	.detail-header h1 {
+		margin: 0;
+	}
+</style>

--- a/src/lib/components/PenDetail.svelte
+++ b/src/lib/components/PenDetail.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { brandName, type Tablet, type PressureResponse } from '$data/lib/drawtab-loader.js';
 	import type { DefectInfo } from '$data/lib/pressure/defects.js';
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import { type Pen, PEN_FIELDS, getPenFamilyName } from '$data/lib/entities/pen-fields.js';
 	import type { InventoryPen } from '$data/lib/entities/inventory-pen-fields.js';
 	import DetailView from '$lib/components/DetailView.svelte';
@@ -98,16 +98,15 @@
 	}
 </script>
 
-<Nav />
-
-<div class="title-row">
-	<h1>{penFullName(pen)}</h1>
-	<FlagButton
-		flagged={$flaggedPenModels.includes(pen.EntityId.toLowerCase())}
-		onclick={() => toggleFlaggedPenModel(pen.EntityId)}
-		label="Flag this pen model"
-	/>
-</div>
+<DetailPageFrame title={penFullName(pen)}>
+	{#snippet actions()}
+		<FlagButton
+			flagged={$flaggedPenModels.includes(pen.EntityId.toLowerCase())}
+			onclick={() => toggleFlaggedPenModel(pen.EntityId)}
+			label="Flag this pen model"
+		/>
+	{/snippet}
+</DetailPageFrame>
 
 <section class="basics">
 	<dl class="basics-grid">
@@ -315,16 +314,6 @@
 {/if}
 
 <style>
-	.title-row {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		margin-bottom: 16px;
-	}
-	.title-row h1 {
-		margin: 0;
-	}
-
 	.basics {
 		margin-bottom: 20px;
 		padding: 12px 16px;

--- a/src/lib/components/TabletDetail.svelte
+++ b/src/lib/components/TabletDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { brandName, type Tablet, type ISOPaperSize } from '$data/lib/drawtab-loader.js';
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import FlagButton from '$lib/components/FlagButton.svelte';
 	import { type Pen } from '$data/lib/entities/pen-fields.js';
 	import { type TabletFamily } from '$data/lib/entities/tablet-family-fields.js';
@@ -47,16 +47,15 @@
 	);
 </script>
 
-<Nav />
-
-<div class="title-row">
-	<h1>{tabletFullName(tablet)}</h1>
-	<FlagButton
-		flagged={$flaggedTablets.includes(tablet.Meta.EntityId)}
-		onclick={() => toggleFlag(tablet.Meta.EntityId)}
-		label="Flag this tablet for comparison"
-	/>
-</div>
+<DetailPageFrame title={tabletFullName(tablet)}>
+	{#snippet actions()}
+		<FlagButton
+			flagged={$flaggedTablets.includes(tablet.Meta.EntityId)}
+			onclick={() => toggleFlag(tablet.Meta.EntityId)}
+			label="Flag this tablet for comparison"
+		/>
+	{/snippet}
+</DetailPageFrame>
 
 <section class="basics">
 	<dl class="basics-grid">
@@ -158,17 +157,6 @@
 </section>
 
 <style>
-	.title-row {
-		display: flex;
-		align-items: baseline;
-		gap: 12px;
-		margin-bottom: 16px;
-	}
-
-	h1 {
-		margin: 0;
-	}
-
 	.basics {
 		margin-bottom: 20px;
 		padding: 12px 16px;


### PR DESCRIPTION
First slice of **#233**. Detail pages repeat the same top chrome: `<Nav/>` + a title row with a flag/actions affordance. `DetailPageFrame` owns that — `Nav` + title + an optional right-aligned **`actions`** slot. The page body (`DetailView`, `Tabs`, …) stays a **sibling after** the frame, deliberately **not** wrapped as children, so each page keeps its own structure and we avoid nesting its top-level snippets (the trap that bit `/pen-analysis` in #231).

Piloted on the two most-alike pages — **PenDetail** and **TabletDetail** (title + flag → `DetailPageFrame` with the `FlagButton` in `actions`). Dead `.title-row`/`h1` CSS removed.

Remaining detail pages (PenFamilyDetail, TabletFamilyDetail, BrandDetail, DriverDetail, SessionDetail, inventory details) adopt it in follow-ups.

> Noticed while here: **PenDetail/TabletDetail still have raw `/entity` `<a>` links** in their basics block — the #238 detail tail didn't actually land for these two. I'll fix that as a separate EntityLink follow-up (kept out of this PR to stay single-purpose).

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: both pages render Nav + title + flag via `DetailPageFrame` (h1 "Wacom Pro Pen (KP-503E)" / "Wacom One 14 (DTC-141)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
