### PR TITLE
refactor(ui): EntityLink for PenDetail/TabletDetail basics links (#238)

### DIFF
--- a/src/lib/components/PenDetail.svelte
+++ b/src/lib/components/PenDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, type Tablet, type PressureResponse } from '$data/lib/drawtab-loader.js';
 	import type { DefectInfo } from '$data/lib/pressure/defects.js';
 	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
@@ -113,9 +114,7 @@
 		<div class="basics-item">
 			<dt>Brand</dt>
 			<dd>
-				<a href={resolve('/entity/[entityId]', { entityId: pen.Brand.toLowerCase() })}
-					>{brandName(pen.Brand)}</a
-				>
+				<EntityLink entityId={pen.Brand.toLowerCase()}>{brandName(pen.Brand)}</EntityLink>
 			</dd>
 		</div>
 		<div class="basics-item">
@@ -136,9 +135,7 @@
 			<div class="basics-item">
 				<dt>Family</dt>
 				<dd>
-					<a href={resolve('/entity/[entityId]', { entityId: pen.PenFamily })}
-						>{getPenFamilyName(pen.PenFamily)}</a
-					>
+					<EntityLink entityId={pen.PenFamily}>{getPenFamilyName(pen.PenFamily)}</EntityLink>
 				</dd>
 			</div>
 		{/if}
@@ -345,13 +342,6 @@
 	.basics-item dd {
 		font-size: 13px;
 		color: var(--text);
-	}
-	.basics-item dd a {
-		color: var(--link);
-		text-decoration: none;
-	}
-	.basics-item dd a:hover {
-		text-decoration: underline;
 	}
 
 	.tab-content {

--- a/src/lib/components/TabletDetail.svelte
+++ b/src/lib/components/TabletDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import EntityLink from '$lib/components/EntityLink.svelte';
 	import { brandName, type Tablet, type ISOPaperSize } from '$data/lib/drawtab-loader.js';
 	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import FlagButton from '$lib/components/FlagButton.svelte';
@@ -62,8 +62,8 @@
 		<div class="basics-item">
 			<dt>Brand</dt>
 			<dd>
-				<a href={resolve('/entity/[entityId]', { entityId: tablet.Model.Brand.toLowerCase() })}
-					>{brandName(tablet.Model.Brand)}</a
+				<EntityLink entityId={tablet.Model.Brand.toLowerCase()}
+					>{brandName(tablet.Model.Brand)}</EntityLink
 				>
 			</dd>
 		</div>
@@ -71,9 +71,7 @@
 			<div class="basics-item">
 				<dt>Family</dt>
 				<dd>
-					<a href={resolve('/entity/[entityId]', { entityId: family.EntityId })}
-						>{family.FamilyName}</a
-					>
+					<EntityLink entityId={family.EntityId}>{family.FamilyName}</EntityLink>
 				</dd>
 			</div>
 		{/if}
@@ -110,7 +108,7 @@
 					{#each includedPenItems as pen, i (pen.entityId)}
 						{#if i > 0},
 						{/if}
-						<a href={resolve('/entity/[entityId]', { entityId: pen.entityId })}>{pen.name}</a>
+						<EntityLink entityId={pen.entityId}>{pen.name}</EntityLink>
 					{/each}
 				</dd>
 			</div>
@@ -192,15 +190,6 @@
 	.basics-item dd {
 		font-size: 13px;
 		color: var(--text);
-	}
-
-	.basics-item dd a {
-		color: var(--link);
-		text-decoration: none;
-	}
-
-	.basics-item dd a:hover {
-		text-decoration: underline;
 	}
 
 	.tab-content {


### PR DESCRIPTION
Closes the **#238 gap** found while doing #233: PenDetail and TabletDetail still rendered raw `<a href={resolve('/entity/[entityId]', …)}>` links in their basics blocks (the detail-page tail in #250 hadn't landed for these two). 

- PenDetail: brand + family → `<EntityLink>` (2)
- TabletDetail: brand + family + included-pen → `<EntityLink>` (3)
- Dead `.basics-item dd a` CSS removed; TabletDetail's now-unused `resolve` import dropped (PenDetail keeps `resolve` for its data-shaped CompatRow/inventory hrefs).

**#238 is now complete** across every markup `/entity` link.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
