### PR TITLE
feat(ui): roll DetailPageFrame across remaining detail pages (#233)

### DIFF
--- a/src/lib/components/BrandDetail.svelte
+++ b/src/lib/components/BrandDetail.svelte
@@ -6,7 +6,7 @@
 	import DetailView from '$lib/components/DetailView.svelte';
 	import EntityLink from '$lib/components/EntityLink.svelte';
 	import ExportTableButton from '$lib/components/ExportTableButton.svelte';
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import Tabs, { type Tab } from '$lib/components/Tabs.svelte';
 	import { tabletNameAndId } from '$lib/tablet-helpers.js';
 
@@ -44,11 +44,7 @@
 	});
 </script>
 
-<Nav />
-
-<div class="title-row">
-	<h1>{brand.BrandName}</h1>
-</div>
+<DetailPageFrame title={brand.BrandName} />
 
 <DetailView item={brand} fields={BRAND_FIELDS} fieldGroups={BRAND_FIELD_GROUPS} />
 
@@ -187,13 +183,6 @@
 </div>
 
 <style>
-	.title-row {
-		margin-bottom: 16px;
-	}
-	h1 {
-		margin: 0;
-	}
-
 	.tabs-section {
 		margin-top: 24px;
 	}

--- a/src/lib/components/DriverDetail.svelte
+++ b/src/lib/components/DriverDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import {
 		type Driver,
 		DRIVER_FIELDS,
@@ -14,7 +14,5 @@
 	let driverName = $derived(nameField ? nameField.getValue(driver) : driver.DriverVersion);
 </script>
 
-<Nav />
-
-<h1>{driverName}</h1>
+<DetailPageFrame title={driverName} />
 <DetailView item={driver} fields={DRIVER_FIELDS} fieldGroups={DRIVER_FIELD_GROUPS} />

--- a/src/lib/components/PenFamilyDetail.svelte
+++ b/src/lib/components/PenFamilyDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import type { Pen, PressureResponse } from '$data/lib/drawtab-loader.js';
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import {
 		type PenFamily,
 		PEN_FAMILY_FIELDS,
@@ -60,16 +60,15 @@
 	let sortedMemberPens: Pen[] = $derived([...memberPens].sort(comparePenByYearDesc));
 </script>
 
-<Nav />
-
-<div class="title-row">
-	<h1>{family.FamilyName}</h1>
-	<FlagButton
-		flagged={$flaggedPenFamilies.includes(family.EntityId.toLowerCase())}
-		onclick={() => toggleFlaggedPenFamily(family.EntityId)}
-		label="Flag this pen family"
-	/>
-</div>
+<DetailPageFrame title={family.FamilyName}>
+	{#snippet actions()}
+		<FlagButton
+			flagged={$flaggedPenFamilies.includes(family.EntityId.toLowerCase())}
+			onclick={() => toggleFlaggedPenFamily(family.EntityId)}
+			label="Flag this pen family"
+		/>
+	{/snippet}
+</DetailPageFrame>
 
 <Tabs
 	tabs={[
@@ -190,16 +189,6 @@
 {/if}
 
 <style>
-	.title-row {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-		margin-bottom: 8px;
-	}
-	.title-row h1 {
-		margin: 0;
-	}
-
 	.tab-content {
 		margin-bottom: 24px;
 	}

--- a/src/lib/components/TabletFamilyDetail.svelte
+++ b/src/lib/components/TabletFamilyDetail.svelte
@@ -2,7 +2,7 @@
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { getDiagonal, type Tablet } from '$data/lib/drawtab-loader.js';
-	import Nav from '$lib/components/Nav.svelte';
+	import DetailPageFrame from '$lib/components/DetailPageFrame.svelte';
 	import {
 		type TabletFamily,
 		TABLET_FAMILY_FIELDS,
@@ -76,9 +76,7 @@
 	);
 </script>
 
-<Nav />
-
-<h1>{family.FamilyName}</h1>
+<DetailPageFrame title={family.FamilyName} />
 <DetailView item={family} fields={TABLET_FAMILY_FIELDS} fieldGroups={TABLET_FAMILY_FIELD_GROUPS} />
 
 <section class="family-section">


### PR DESCRIPTION
Continues **#233** (after the PenDetail/TabletDetail pilot in #257). Adopts `DetailPageFrame` on:

- **PenFamilyDetail** — title + flag (`FlagButton` in `actions`)
- **TabletFamilyDetail**, **DriverDetail** — bare title
- **BrandDetail** — title only

Dead `.title-row`/`h1` CSS removed.

**Intentionally left as-is:** `SessionDetail` (renders a `SubNav`, not just `Nav` — different shape) and the inventory detail pages (their header carries a *model link*, not an action). These don't fit the `Nav` + title + `actions` shape; forcing them would distort the header.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: BrandDetail renders Nav + title via `DetailPageFrame` (h1 "Wacom").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
