### PR TITLE
refactor(ui): route remaining action buttons onto Button (#239)

### DIFF
--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Button from '$lib/components/Button.svelte';
 	import type { AnyFieldDisplayDef } from '@thesevenpens/queriton';
 
 	interface QuickFilterOption {
@@ -61,7 +62,7 @@
 		</label>
 	{/if}
 	{#if isDirty}
-		<button class="clear-btn" onclick={clear}>Clear</button>
+		<Button variant="subtle" onclick={clear}>Clear</Button>
 	{/if}
 </div>
 
@@ -127,19 +128,5 @@
 	}
 	.owned-toggle input {
 		margin: 0;
-	}
-
-	.clear-btn {
-		padding: 5px 10px;
-		font-size: 13px;
-		border: 1px solid var(--border-light);
-		border-radius: 4px;
-		background: var(--bg-card);
-		color: var(--text-muted);
-		cursor: pointer;
-	}
-
-	.clear-btn:hover {
-		border-color: var(--text-muted);
 	}
 </style>

--- a/src/routes/pen-compare/+page.svelte
+++ b/src/routes/pen-compare/+page.svelte
@@ -393,7 +393,7 @@
 
 {#if activeTab === 'flagged'}
 	<div class="flagged-actions">
-		<button class="add-pen-btn" onclick={() => (showPicker = true)}>+ Add pen</button>
+		<Button variant="secondary" onclick={() => (showPicker = true)}>+ Add pen</Button>
 		{#if flaggedItems.length > 0}
 			<Button variant="subtle" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</Button>
 			<Button variant="danger" onclick={clearFlaggedPenModels}>Clear all</Button>
@@ -701,22 +701,6 @@
 		align-items: center;
 		gap: 8px;
 		margin-bottom: 12px;
-	}
-
-	.add-pen-btn {
-		padding: 5px 14px;
-		font-size: 13px;
-		font-weight: 600;
-		border: 1px solid #2563eb;
-		border-radius: 4px;
-		background: #2563eb;
-		color: #fff;
-		cursor: pointer;
-	}
-
-	.add-pen-btn:hover:not(:disabled) {
-		background: #1d4ed8;
-		border-color: #1d4ed8;
 	}
 
 	.flagged-list {

--- a/src/routes/tablet-compare/+page.svelte
+++ b/src/routes/tablet-compare/+page.svelte
@@ -209,12 +209,12 @@
 
 {#if activeTab === 'flagged'}
 	<div class="flagged-actions">
-		<button
-			class="add-tablet-btn"
+		<Button
+			variant="secondary"
 			onclick={() => (showPicker = true)}
 			disabled={$flaggedTablets.length >= 6}
-			title={$flaggedTablets.length >= 6 ? 'All 6 slots are used' : 'Add a tablet to compare'}
-			>+ Add tablet</button
+			disabledReason="All 6 slots are used"
+			title="Add a tablet to compare">+ Add tablet</Button
 		>
 		{#if flaggedItems.length > 0}
 			<Button variant="subtle" onclick={copyFlaggedList}>{copyFlaggedStatus || 'Copy list'}</Button>
@@ -464,27 +464,6 @@
 		align-items: center;
 		gap: 8px;
 		margin-bottom: 12px;
-	}
-
-	.add-tablet-btn {
-		padding: 5px 14px;
-		font-size: 13px;
-		font-weight: 600;
-		border: 1px solid #2563eb;
-		border-radius: 4px;
-		background: #2563eb;
-		color: #fff;
-		cursor: pointer;
-	}
-
-	.add-tablet-btn:hover:not(:disabled) {
-		background: #1d4ed8;
-		border-color: #1d4ed8;
-	}
-
-	.add-tablet-btn:disabled {
-		opacity: 0.45;
-		cursor: default;
 	}
 
 	.flagged-list {


### PR DESCRIPTION
Final Button-adoption polish (#239):
- **SearchBar "Clear"** → `<Button variant="subtle">` (the in-input ✕ clear stays as its own affordance).
- **/pen-compare "+ Add pen"** and **/tablet-compare "+ Add tablet"** → `<Button variant="secondary">`. The tablet add button's capped-state title moves to **`disabledReason`** (shown when 6 slots are full), preserving the enable/disable tooltip behavior.

Dead `.clear-btn` / `.add-pen-btn` / `.add-tablet-btn` CSS removed.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: "+ Add tablet" renders as the `secondary` Button with title "Add a tablet to compare".

Remaining optional adoption (low-value, can be incremental): `/reference`'s in-snippet section headers → `SectionHeader`, the tiny query-bar `+` toolbar buttons, and multi-line empty-workflow CTAs → `EmptyState` `action` slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
