### PR TITLE
refactor(ui): multi-line empty-workflow states -> EmptyState (#237)

### DIFF
--- a/src/routes/pen-compare/+page.svelte
+++ b/src/routes/pen-compare/+page.svelte
@@ -413,17 +413,17 @@
 			{/each}
 		</ul>
 	{:else}
-		<p class="no-data">
+		<EmptyState>
 			No pens added yet. Use the button above, or flag pens from the <a href={resolve('/pens')}
 				>pens list</a
 			> or individual pen pages.
-		</p>
+		</EmptyState>
 	{/if}
 {:else if activeTab === 'compare'}
 	{#if flaggedItems.length < 2}
-		<p class="no-data">
+		<EmptyState>
 			Flag at least 2 pens to compare. Currently {flaggedItems.length} flagged.
-		</p>
+		</EmptyState>
 	{:else}
 		<div class="compare-toolbar">
 			<Button
@@ -466,14 +466,14 @@
 	{/if}
 {:else if activeTab === 'pressure'}
 	{#if $flaggedPenTotalCount === 0}
-		<p class="no-data">
+		<EmptyState>
 			Nothing flagged. Flag a pen model from the <a href={resolve('/pens')}>pens list</a>, a pen
 			family, or a pen unit to see its sessions overlaid here.
-		</p>
+		</EmptyState>
 	{:else if matchedSessions.length === 0}
-		<p class="no-data">
+		<EmptyState>
 			Flagged: {flagSummary}. No pressure-response sessions match the current flags.
-		</p>
+		</EmptyState>
 	{:else}
 		<div class="overlay-toolbar">
 			<p class="overlay-summary">
@@ -512,9 +512,9 @@
 	{/if}
 {:else if activeTab === 'iaf'}
 	{#if flaggedItems.length === 0}
-		<p class="no-data">
+		<EmptyState>
 			Flag at least one pen to see its Piaf chart. Currently {flaggedItems.length} flagged.
-		</p>
+		</EmptyState>
 	{:else}
 		<section class="group-section">
 			<h2 class="group-heading">All flagged pens — combined</h2>
@@ -558,9 +558,9 @@
 	{/if}
 {:else if activeTab === 'max'}
 	{#if flaggedItems.length === 0}
-		<p class="no-data">
+		<EmptyState>
 			Flag at least one pen to see its Pmax chart. Currently {flaggedItems.length} flagged.
-		</p>
+		</EmptyState>
 	{:else}
 		{#if anyCombinedData}
 			<section class="per-pen-section combined-section">
@@ -804,16 +804,6 @@
 
 	.differs {
 		background: #fef3c7;
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
-	}
-
-	.no-data a {
-		color: var(--link);
 	}
 
 	.overlay-toolbar {

--- a/src/routes/pen-flagged/+page.svelte
+++ b/src/routes/pen-flagged/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { brandName, type Pen, type PenFamily } from '$data/lib/drawtab-loader.js';
 	import { penIdRedundantInName } from '$data/lib/entities/pen-fields.js';
@@ -88,9 +89,9 @@
 </div>
 
 {#if $flaggedPenTotalCount === 0}
-	<p class="empty">
+	<EmptyState>
 		Nothing flagged yet. Open a pen, pen family, or inventory pen and click the ⚐ button to flag it.
-	</p>
+	</EmptyState>
 {:else}
 	{#if flaggedModelEntries.length > 0}
 		<section>
@@ -168,12 +169,6 @@
 		margin: 0;
 		color: var(--text-muted);
 		font-size: 13px;
-	}
-	.empty {
-		margin: 24px 0;
-		font-size: 14px;
-		color: var(--text-muted);
-		font-style: italic;
 	}
 	section h2 {
 		font-size: 16px;

--- a/src/routes/tablet-compare/+page.svelte
+++ b/src/routes/tablet-compare/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { resolve } from '$app/paths';
 	import { getDiagonal, type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
 	import Button from '$lib/components/Button.svelte';
@@ -235,17 +236,17 @@
 			{/each}
 		</ul>
 	{:else}
-		<p class="no-data">
+		<EmptyState>
 			No tablets added yet. Use the button above, or flag tablets from the <a href={resolve('/')}
 				>tablets list</a
 			> or individual tablet pages.
-		</p>
+		</EmptyState>
 	{/if}
 {:else if activeTab === 'compare'}
 	{#if flaggedItems.length < 2}
-		<p class="no-data">
+		<EmptyState>
 			Flag at least 2 tablets to compare. Currently {flaggedItems.length} flagged.
-		</p>
+		</EmptyState>
 	{:else}
 		<div class="compare-toolbar">
 			<Button
@@ -288,9 +289,9 @@
 	{/if}
 {:else if activeTab === 'sizes'}
 	{#if flaggedItems.length < 2}
-		<p class="no-data">
+		<EmptyState>
 			Flag at least 2 tablets to compare. Currently {flaggedItems.length} flagged.
-		</p>
+		</EmptyState>
 	{:else}
 		{#if dimCompItems.length >= 2}
 			<section class="hist-section">
@@ -567,15 +568,5 @@
 
 	.differs {
 		background: #fef3c7;
-	}
-
-	.no-data {
-		font-size: 13px;
-		color: var(--text-dim);
-		font-style: italic;
-	}
-
-	.no-data a {
-		color: var(--link);
 	}
 </style>


### PR DESCRIPTION
Final **#237** adoption. Converts the multi-line empty-workflow blocks (with their inline "flag something first" CTA links) to `<EmptyState>`:

- `/pen-compare` (6), `/tablet-compare` (3) — flagged-list + compare-tab empties
- `/pen-flagged` (1) — the "nothing flagged yet" state

CTA links stay inline as `EmptyState` children. Dead `.no-data a` / `.empty` CSS removed. (`/pressure-backfill`'s dev-only `.empty` lines left as-is.)

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: the pen-compare flagged-empty state renders as `EmptyState` (italic) with its inline links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
