### PR TITLE
feat(nav): move Brands from top-level nav into Data sub-nav

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -13,7 +13,6 @@
 	};
 
 	const links: LinkSpec[] = [
-		{ href: '/brands', label: 'Brands' },
 		{
 			href: '/tablets',
 			label: 'Tablets',
@@ -37,6 +36,7 @@
 			href: '/reference',
 			label: 'Data',
 			altActive: [
+				'/brands',
 				'/data-dictionary',
 				'/api-explorer',
 				'/data-quality',

--- a/src/lib/nav/subnav-tabs.ts
+++ b/src/lib/nav/subnav-tabs.ts
@@ -21,6 +21,7 @@ export function tabletSubNavTabs(opts: { flaggedCount?: number } = {}): SubNavTa
 export function dataSubNavTabs(): SubNavTab[] {
 	return [
 		{ href: '/reference', label: 'Reference' },
+		{ href: '/brands', label: 'Brands' },
 		{ href: '/data-dictionary', label: 'Data Dictionary' },
 		{ href: '/api-explorer', label: 'API Explorer' },
 		{ href: '/data-quality', label: 'Data Quality' },

--- a/src/routes/brands/+page.svelte
+++ b/src/routes/brands/+page.svelte
@@ -6,12 +6,14 @@
 		BRAND_DEFAULT_VIEW,
 	} from '$data/lib/entities/brand-fields.js';
 	import EntityListLayout from '$lib/components/EntityListLayout.svelte';
+	import { dataSubNavTabs } from '$lib/nav/subnav-tabs.js';
 
 	let { data } = $props();
 </script>
 
 <EntityListLayout
 	title="Brands"
+	subNavTabs={dataSubNavTabs()}
 	entityType="brands"
 	entityLabel="brands"
 	data={data.brands}


### PR DESCRIPTION
Brands is reference data, so it now lives under **Data** (next to Reference) instead of as its own top-level tab.

- **`Nav.svelte`** — drop the top-level "Brands" link; add `/brands` to the Data entry's `altActive` so the **Data** top tab highlights on the brands page.
- **`subnav-tabs.ts`** — add "Brands" to `dataSubNavTabs()`, right after Reference.
- **`/brands/+page.svelte`** — pass `subNavTabs={dataSubNavTabs()}` so the page renders the Data sub-nav with **Brands** active.

**Verification:** check 0 · lint 0 · 558 unit · 28 e2e. Preview: top nav is now Tablets / Pens / Drivers / Timeline / Data / About (no Brands); `/brands` shows the Data sub-nav (**Reference · Brands · Data Dictionary · …**) with Brands active and the Data top tab active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
