### PR TITLE
feat(pens,tablets): split Name/Model ID columns; add Brand to pens list

### DIFF
--- a/src/routes/pens/+page.svelte
+++ b/src/routes/pens/+page.svelte
@@ -56,7 +56,7 @@
 	fieldGroups={PEN_FIELD_GROUPS}
 	defaultColumns={PEN_DEFAULT_COLUMNS}
 	defaultView={PEN_DEFAULT_VIEW}
-	linkField="FullName"
+	linkField="PenName"
 	detailBasePath="/entity"
 	{cellLinks}
 	defaultFilterField="PenFamily"

--- a/src/routes/tablets/+page.svelte
+++ b/src/routes/tablets/+page.svelte
@@ -42,7 +42,7 @@
 	defaultColumns={TABLET_DEFAULT_COLUMNS}
 	defaultView={TABLET_DEFAULT_VIEW}
 	detailBasePath="/entity"
-	linkField="NameAndModelId"
+	linkField="ModelName"
 	{cellLinks}
 	defaultFilterField="Brand"
 	quickFilterFields={['Brand', 'ModelType', 'DigitizerSizeCategory']}


### PR DESCRIPTION
Adjusts the default list-view columns for the Pens and Tablets pages.

### Pens
- **Add a Brand column.**
- Replace the combined **Full Name** column with separate **Name** and **Pen ID** columns.
- The detail link now sits on the **Name** column (`linkField` → `PenName`).

### Tablets
- Replace the combined **Name and Model ID** column with separate **Name** and **Model ID** columns.
- The detail link now sits on the **Name** column (`linkField` → `ModelName`).

### How
Visible columns come from each entity's `DEFAULT_VIEW` select step in the data-repo field defs, so the column change is a data-repo commit (TheSevenPens/DrawTabData@eacbfef, on `master`); this PR bumps the submodule pointer to it and updates the two routes' `linkField`. The `FullName` / `NameAndModelId` computed fields remain in the field list and column picker — only the default visible set changed.

> Note: on the Pens list the model-id column keeps its canonical label **"Pen ID"** (the `PenId` field's label app-wide) rather than literally "Model ID", for consistency with the rest of the UI. Easy to relabel if preferred.

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors · 558 unit · 26 e2e. Preview-confirmed headers:
- Pens: `Brand · Name · Pen ID · Family · …` (Name links to `/entity/<brand>.pen.<id>`)
- Tablets: `Brand · Name · Model ID · Alternate Names · …` (Name links to `/entity/<brand>.tablet.<id>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)