### PR TITLE
style: remove purple from heading text and active backgrounds

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -158,12 +158,8 @@
 
 	/* toggle pressed state (used with subtle/menu-trigger for view toggles) */
 	.btn[aria-pressed='true'] {
-		color: #6b21a8;
+		color: var(--text);
 		border-color: var(--border);
 		font-weight: 600;
-	}
-
-	:global([data-theme='dark']) .btn[aria-pressed='true'] {
-		color: #c4b5fd;
 	}
 </style>

--- a/src/lib/components/ChartFrame.svelte
+++ b/src/lib/components/ChartFrame.svelte
@@ -57,7 +57,7 @@
 		margin: 0;
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 	}
 
 	.cf-subtitle {

--- a/src/lib/components/DetailView.svelte
+++ b/src/lib/components/DetailView.svelte
@@ -71,7 +71,7 @@
 	h2 {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 8px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid var(--border);

--- a/src/lib/components/PressureRangeTab.svelte
+++ b/src/lib/components/PressureRangeTab.svelte
@@ -411,7 +411,7 @@
 	}
 	.view-toggle button.active {
 		background: var(--bg);
-		color: #6b21a8;
+		color: var(--text);
 		font-weight: 600;
 	}
 

--- a/src/lib/components/SectionHeader.svelte
+++ b/src/lib/components/SectionHeader.svelte
@@ -47,7 +47,7 @@
 	.section-header h2 {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin: 0;
 		padding: 0;
 		border: none;

--- a/src/lib/components/SegmentedControl.svelte
+++ b/src/lib/components/SegmentedControl.svelte
@@ -68,11 +68,7 @@
 
 	.segmented button.active {
 		background: var(--bg);
-		color: #6b21a8;
+		color: var(--text);
 		font-weight: 600;
-	}
-
-	:global([data-theme='dark']) .segmented button.active {
-		color: #c4b5fd;
 	}
 </style>

--- a/src/lib/components/SortBar.svelte
+++ b/src/lib/components/SortBar.svelte
@@ -298,7 +298,7 @@
 	}
 	.sort-pill .arrow {
 		font-size: 10px;
-		color: #6b21a8;
+		color: var(--text);
 	}
 
 	.add-btn {

--- a/src/lib/components/TableFrame.svelte
+++ b/src/lib/components/TableFrame.svelte
@@ -69,7 +69,7 @@
 		margin: 0;
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;

--- a/src/lib/components/TabletFamilyDetail.svelte
+++ b/src/lib/components/TabletFamilyDetail.svelte
@@ -249,8 +249,8 @@
 	}
 
 	.stack-toggle.active {
-		background: #ede9fe;
-		border-color: #7c3aed;
+		background: var(--hover-bg);
+		border-color: var(--link);
 		color: var(--text);
 	}
 </style>

--- a/src/lib/components/TabletFamilyDetail.svelte
+++ b/src/lib/components/TabletFamilyDetail.svelte
@@ -182,7 +182,7 @@
 	.family-section h2 {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 8px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid #e0e0e0;
@@ -251,6 +251,6 @@
 	.stack-toggle.active {
 		background: #ede9fe;
 		border-color: #7c3aed;
-		color: #7c3aed;
+		color: var(--text);
 	}
 </style>

--- a/src/lib/components/tablet-detail/TabletModelTab.svelte
+++ b/src/lib/components/tablet-detail/TabletModelTab.svelte
@@ -108,7 +108,7 @@
 	h2 {
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 0;
 	}
 

--- a/src/lib/components/tablet-detail/TabletSpecsTab.svelte
+++ b/src/lib/components/tablet-detail/TabletSpecsTab.svelte
@@ -156,7 +156,7 @@
 	h2 {
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 0;
 	}
 

--- a/src/lib/reference/DriverCompatSection.svelte
+++ b/src/lib/reference/DriverCompatSection.svelte
@@ -81,7 +81,7 @@
 	h2 {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin: 0 0 8px;
 	}
 	.meta {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -271,7 +271,7 @@
 
 	:global(.step-type) {
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		min-width: 60px;
 		padding-top: 4px;
 	}

--- a/src/routes/data-dictionary/+page.svelte
+++ b/src/routes/data-dictionary/+page.svelte
@@ -301,7 +301,7 @@
 	h2 {
 		font-size: 18px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin: 0;
 	}
 

--- a/src/routes/pen-analysis/+page.svelte
+++ b/src/routes/pen-analysis/+page.svelte
@@ -670,7 +670,7 @@
 	:global(.section h2) {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 8px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid var(--border);

--- a/src/routes/pen-compare/+page.svelte
+++ b/src/routes/pen-compare/+page.svelte
@@ -792,7 +792,7 @@
 	.group-header {
 		font-weight: 700;
 		background: var(--th-bg);
-		color: #6b21a8;
+		color: var(--text);
 		font-size: 12px;
 		text-transform: uppercase;
 		letter-spacing: 0.5px;
@@ -845,7 +845,7 @@
 	.group-heading {
 		font-size: 16px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin: 0 0 12px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid var(--border);
@@ -872,7 +872,7 @@
 	.per-pen-heading {
 		font-size: 16px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin: 0 0 12px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid var(--border);
@@ -1021,7 +1021,7 @@
 
 	.view-toggle button.active {
 		background: var(--bg);
-		color: #6b21a8;
+		color: var(--text);
 		font-weight: 600;
 	}
 </style>

--- a/src/routes/reference/+page.svelte
+++ b/src/routes/reference/+page.svelte
@@ -637,7 +637,7 @@
 	h2 {
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 0;
 	}
 

--- a/src/routes/tablet-analysis/+page.svelte
+++ b/src/routes/tablet-analysis/+page.svelte
@@ -405,7 +405,7 @@
 	:global(.section h2) {
 		font-size: 15px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 8px;
 		padding-bottom: 4px;
 		border-bottom: 2px solid var(--border);

--- a/src/routes/tablet-compare/+page.svelte
+++ b/src/routes/tablet-compare/+page.svelte
@@ -414,14 +414,14 @@
 	.stack-toggle.active {
 		background: #ede9fe;
 		border-color: #7c3aed;
-		color: #6b21a8;
+		color: var(--text);
 		font-weight: 600;
 	}
 
 	.hist-section h2 {
 		font-size: 14px;
 		font-weight: 600;
-		color: #6b21a8;
+		color: var(--text);
 		margin-bottom: 6px;
 		padding-bottom: 3px;
 		border-bottom: 2px solid var(--border);
@@ -556,7 +556,7 @@
 	.group-header {
 		font-weight: 700;
 		background: var(--th-bg);
-		color: #6b21a8;
+		color: var(--text);
 		font-size: 12px;
 		text-transform: uppercase;
 		letter-spacing: 0.5px;

--- a/src/routes/tablet-compare/+page.svelte
+++ b/src/routes/tablet-compare/+page.svelte
@@ -412,8 +412,8 @@
 		color: var(--text);
 	}
 	.stack-toggle.active {
-		background: #ede9fe;
-		border-color: #7c3aed;
+		background: var(--hover-bg);
+		border-color: var(--link);
 		color: var(--text);
 		font-weight: 600;
 	}


### PR DESCRIPTION
Purple read as an "AI-generated" tell, so this removes it from the UI **text** and **active-state backgrounds**, while leaving the chart series palettes purple (as requested).

### Heading / label text
- Bulk `color: #6b21a8` → `color: var(--text)` across 19 files — section headings (e.g. "Pen Tablet Size Categories"), `ChartFrame`/`TableFrame`/`SectionHeader` titles, SortBar arrow accent, detail-tab headings.
- Removed the now-redundant dark-mode `color: #c4b5fd` overrides on `Button` (`aria-pressed`) and `SegmentedControl` (`.active`) — `var(--text)` covers both themes; active still reads via bold weight + background/border.
- `TabletFamilyDetail .stack-toggle.active` text → `var(--text)`.

### Active-state backgrounds
- The two `.stack-toggle.active` states (tablet-compare dimension chart, TabletFamilyDetail stacking toggle) used light-purple `#ede9fe` bg + `#7c3aed` border → now `var(--hover-bg)` + `var(--link)` (the app's blue active convention). Bonus: they're now theme-aware (previously had no dark-mode variant).

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors · 26 e2e green. Preview-confirmed: "Pen Tablet Size Categories" computes to `rgb(34,34,34)` (body text); no `#ede9fe`/`#7c3aed`/`#6d28d9` left in computed styles on `/tablet-compare`.

### Intentionally left (charts) + flagged for your call
- **Charts keep purple** series colors (`chart-palette.ts`, `TabletDimensionComparison` stacks) — per request.
- **Not touched, please advise:** two non-chart purple spots that aren't "active backgrounds":
  - `TabletPicker` `.type-pendisplay` **type badge** — `#ede9fe` bg + `#6d28d9` text (a categorical color like a legend).
  - `BrandDetail` card **accent border** — `border-left: 3px solid #7c3aed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)