### PR TITLE
feat(timeline): add Year-Month grouping option

### DIFF
--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -1,53 +1,122 @@
 <script lang="ts">
 	import { base, resolve } from '$app/paths';
 	import { untrack } from 'svelte';
-	import { brandName } from '$data/lib/drawtab-loader.js';
+	import { brandName, type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
 
 	let { data } = $props();
 
-	let timeline = $derived(data.timeline);
+	let tablets: Tablet[] = $derived(data.tablets);
+	let pens: Pen[] = $derived(data.pens);
 	let brands = $derived(data.brands);
-	let allYears = $derived(data.allYears);
 
 	let filterBrand = $state('');
 	let filterType = $state('');
 	let sortOrder: 'newest' | 'oldest' = $state('newest');
-	// yearFrom/yearTo are user-editable range inputs seeded from the
-	// loaded data once. `untrack` tells the compiler the initial-value
-	// read is deliberate.
+	let groupBy: 'year' | 'year-month' = $state('year');
+	// yearFrom/yearTo are user-editable range inputs seeded from the loaded
+	// data once. `untrack` tells the compiler the initial read is deliberate.
 	let yearFrom = $state(untrack(() => data.yearFrom));
 	let yearTo = $state(untrack(() => data.yearTo));
 
-	let filteredTimeline = $derived.by(() => {
-		let result = timeline;
+	const MONTHS = [
+		'',
+		'Jan',
+		'Feb',
+		'Mar',
+		'Apr',
+		'May',
+		'Jun',
+		'Jul',
+		'Aug',
+		'Sep',
+		'Oct',
+		'Nov',
+		'Dec',
+	];
+
+	interface Period {
+		sort: string;
+		year: string;
+		month: number | null; // 1-12 when known
+		monthUnknown: boolean; // year-month mode, item has no month
+		tablets: Tablet[];
+		pens: Pen[];
+	}
+
+	// Period bucket for an item. In year mode everything keys on the launch
+	// year. In year-month mode, tablets with a month-precision ReleaseDate
+	// (YYYY-MM…) key on that month; year-only dates and all pens (which have
+	// no release date) drop into a per-year "month unknown" bucket.
+	function periodKey(year: string, releaseDate: string | undefined) {
+		if (groupBy === 'year-month' && releaseDate && /^\d{4}-\d{2}/.test(releaseDate)) {
+			const ym = releaseDate.slice(0, 7);
+			return { sort: ym, year: ym.slice(0, 4), month: Number(ym.slice(5, 7)), monthUnknown: false };
+		}
+		if (groupBy === 'year-month') {
+			return { sort: `${year}-00`, year, month: null, monthUnknown: true };
+		}
+		return { sort: year, year, month: null, monthUnknown: false };
+	}
+
+	let groupedTimeline = $derived.by(() => {
 		const from = Number(yearFrom);
 		const to = Number(yearTo);
-		if (!isNaN(from) && !isNaN(to)) {
-			result = result.filter((e) => {
-				const y = Number(e.year);
-				return !isNaN(y) && y >= from && y <= to;
-			});
-		}
-		if (sortOrder === 'oldest') {
-			result = [...result].reverse();
-		}
-		return result.map((entry) => {
-			let tablets = entry.tablets;
-			let pens = entry.pens;
-			if (filterBrand) {
-				tablets = tablets.filter((t) => t.Model.Brand === filterBrand);
-				pens = pens.filter((p) => p.Brand === filterBrand);
+		const inRange = (y: string) => {
+			const n = Number(y);
+			if (isNaN(n)) return false;
+			if (isNaN(from) || isNaN(to)) return true;
+			return n >= from && n <= to;
+		};
+
+		// Transient local accumulator rebuilt each computation, not reactive
+		// state — a plain Map is correct (no SvelteMap reactivity needed).
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const map = new Map<string, Period>();
+		const ensure = (k: Omit<Period, 'tablets' | 'pens'>) => {
+			let p = map.get(k.sort);
+			if (!p) {
+				p = { ...k, tablets: [], pens: [] };
+				map.set(k.sort, p);
 			}
-			if (filterType) {
-				tablets = tablets.filter((t) => t.Model.Type === filterType);
+			return p;
+		};
+
+		for (const t of tablets) {
+			if (filterBrand && t.Model.Brand !== filterBrand) continue;
+			if (filterType && t.Model.Type !== filterType) continue;
+			if (!inRange(t.Model.LaunchYear)) continue;
+			ensure(periodKey(t.Model.LaunchYear, t.Model.ReleaseDate)).tablets.push(t);
+		}
+		// Type is a tablet property, so the type filter doesn't apply to pens
+		// (matches prior behavior); pens still honor brand + year-range filters.
+		for (const p of pens) {
+			if (filterBrand && p.Brand !== filterBrand) continue;
+			if (!inRange(p.PenYear)) continue;
+			ensure(periodKey(p.PenYear, undefined)).pens.push(p);
+		}
+
+		// Year mode fills empty years across the visible range so gaps read as
+		// "No releases". Year-month mode would explode into mostly-empty months,
+		// so it only lists periods that actually have releases.
+		if (groupBy === 'year' && !isNaN(from) && !isNaN(to)) {
+			for (let y = from; y <= to; y++) {
+				const k = String(y);
+				if (!map.has(k))
+					map.set(k, { sort: k, year: k, month: null, monthUnknown: false, tablets: [], pens: [] });
 			}
-			return { year: entry.year, tablets, pens };
-		});
+		}
+
+		const periods = [...map.values()];
+		periods.sort((a, b) =>
+			sortOrder === 'newest' ? b.sort.localeCompare(a.sort) : a.sort.localeCompare(b.sort),
+		);
+		return periods;
 	});
 
-	let totalTablets = $derived(filteredTimeline.reduce((sum, e) => sum + e.tablets.length, 0));
-	let totalPens = $derived(filteredTimeline.reduce((sum, e) => sum + e.pens.length, 0));
+	let totalTablets = $derived(groupedTimeline.reduce((sum, e) => sum + e.tablets.length, 0));
+	let totalPens = $derived(groupedTimeline.reduce((sum, e) => sum + e.pens.length, 0));
+	let periodNoun = $derived(groupBy === 'year' ? 'years' : 'periods');
 </script>
 
 <Nav />
@@ -55,7 +124,7 @@
 <div class="title-row">
 	<h1>Timeline</h1>
 	<span class="subtitle"
-		>{filteredTimeline.length} years, {totalTablets} tablets, {totalPens} pens</span
+		>{groupedTimeline.length} {periodNoun}, {totalTablets} tablets, {totalPens} pens</span
 	>
 </div>
 
@@ -72,28 +141,33 @@
 		<option value="PENDISPLAY">Pen Display</option>
 		<option value="STANDALONE">Standalone</option>
 	</select>
+	<select bind:value={groupBy}>
+		<option value="year">Group by Year</option>
+		<option value="year-month">Group by Year-Month</option>
+	</select>
 	<select bind:value={sortOrder}>
 		<option value="newest">Newest First</option>
 		<option value="oldest">Oldest First</option>
 	</select>
 	<span class="year-range">
 		<label for="year-from">From</label>
-		<input id="year-from" type="number" bind:value={yearFrom} min={allYears[0]} max={yearTo} />
+		<input id="year-from" type="number" bind:value={yearFrom} min={data.minYear} max={yearTo} />
 		<label for="year-to">To</label>
-		<input
-			id="year-to"
-			type="number"
-			bind:value={yearTo}
-			min={yearFrom}
-			max={allYears[allYears.length - 1]}
-		/>
+		<input id="year-to" type="number" bind:value={yearTo} min={yearFrom} max={data.maxYear} />
 	</span>
 </div>
 
 <div class="timeline">
-	{#each filteredTimeline as entry (entry.year)}
+	{#each groupedTimeline as entry (entry.sort)}
 		<div class="year-block">
-			<div class="year-label">{entry.year}</div>
+			<div class="year-label">
+				<span class="period-year">{entry.year}</span>
+				{#if entry.month}
+					<span class="period-month">{MONTHS[entry.month]}</span>
+				{:else if entry.monthUnknown}
+					<span class="period-month dim">no month</span>
+				{/if}
+			</div>
 			<div class="year-content">
 				{#if entry.tablets.length === 0 && entry.pens.length === 0}
 					<p class="no-releases">No releases</p>
@@ -164,6 +238,7 @@
 		display: flex;
 		gap: 8px;
 		margin-bottom: 20px;
+		flex-wrap: wrap;
 	}
 
 	.filters select {
@@ -216,11 +291,30 @@
 		position: absolute;
 		left: -80px;
 		top: 0;
-		width: 60px;
+		width: 64px;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		text-align: right;
+	}
+
+	.period-year {
 		font-size: 20px;
 		font-weight: 700;
 		color: var(--text);
-		text-align: right;
+		line-height: 1.1;
+	}
+
+	.period-month {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+
+	.period-month.dim {
+		font-weight: 500;
+		color: var(--text-dim);
+		font-style: italic;
 	}
 
 	.year-content {

--- a/src/routes/timeline/+page.ts
+++ b/src/routes/timeline/+page.ts
@@ -1,11 +1,3 @@
-import type { Tablet, Pen } from '$data/lib/drawtab-loader.js';
-
-interface YearEntry {
-	year: string;
-	tablets: Tablet[];
-	pens: Pen[];
-}
-
 export async function load({ parent }) {
 	const { ds } = await parent();
 	const [tablets, pens] = await Promise.all([ds.Tablets.toArray(), ds.Pens.toArray()]);
@@ -14,43 +6,25 @@ export async function load({ parent }) {
 		...new Set([...tablets.map((t) => t.Model.Brand), ...pens.map((p) => p.Brand)]),
 	].sort();
 
-	const yearMap = new Map<string, { tablets: Tablet[]; pens: Pen[] }>();
-
-	for (const t of tablets) {
-		if (!t.Model.LaunchYear) continue;
-		if (!yearMap.has(t.Model.LaunchYear))
-			yearMap.set(t.Model.LaunchYear, { tablets: [], pens: [] });
-		yearMap.get(t.Model.LaunchYear)!.tablets.push(t);
-	}
-
-	for (const p of pens) {
-		if (!p.PenYear) continue;
-		if (!yearMap.has(p.PenYear)) yearMap.set(p.PenYear, { tablets: [], pens: [] });
-		yearMap.get(p.PenYear)!.pens.push(p);
-	}
-
-	const years = [...yearMap.keys()].map(Number).filter((y) => !isNaN(y));
-	const allYears = years.sort((a, b) => a - b);
-
-	// Fill in gap years that have no releases.
-	if (years.length >= 2) {
-		const minYear = Math.min(...years);
-		const maxYear = Math.max(...years);
-		for (let y = minYear; y <= maxYear; y++) {
-			const key = String(y);
-			if (!yearMap.has(key)) yearMap.set(key, { tablets: [], pens: [] });
-		}
-	}
-
-	const timeline: YearEntry[] = [...yearMap.entries()]
-		.map(([year, d]) => ({ year, ...d }))
-		.sort((a, b) => b.year.localeCompare(a.year));
+	// Grouping (by year, or by year-month using tablet ReleaseDate) depends on a
+	// user toggle, so it lives in +page.svelte. The loader just hands over the
+	// raw entities plus the year range used to seed the From/To inputs.
+	// Number("") is 0, not NaN, so guard against blank years collapsing the
+	// range — only count plausible 4-digit years.
+	const years = [
+		...tablets.map((t) => Number(t.Model.LaunchYear)),
+		...pens.map((p) => Number(p.PenYear)),
+	].filter((y) => !isNaN(y) && y >= 1900 && y <= 2200);
+	const minYear = Math.min(...years);
+	const maxYear = Math.max(...years);
 
 	return {
-		timeline,
+		tablets,
+		pens,
 		brands,
-		allYears,
-		yearFrom: String(Math.min(...years)),
-		yearTo: String(Math.max(...years)),
+		minYear,
+		maxYear,
+		yearFrom: String(minYear),
+		yearTo: String(maxYear),
 	};
 }


### PR DESCRIPTION
Adds a **Group by** toggle to the Timeline — **Year** (default, unchanged) or **Year-Month**, now that tablets carry a month-precision `Model.ReleaseDate`.

### Behavior
- **Year-Month** buckets tablets by their `ReleaseDate` month (`YYYY-MM`). Items without a month — year-only release dates and **all pens** (pens have no release date) — fall into a per-year **"no month"** bucket, so nothing is dropped. 159 Wacom tablets have month-precision dates, so the month buckets are well-populated.
- **Year** mode is unchanged, including the gap-year fill that shows empty years as "No releases". Year-Month omits the fill (it would explode into mostly-empty month rows).
- Period label stacks year + month (e.g. **2025 / Sep**); the summary count switches "years" → "periods".

### Implementation
- Grouping moved from `+page.ts` into a `$derived.by` in the component, since it now depends on the user-selected mode (per the CLAUDE.md guidance: user-editable-state-dependent shaping goes in `$derived`). The loader returns the raw tablets/pens + the year range for the From/To inputs.
- Guards a blank-year footgun: `Number("")` is `0` (not `NaN`), which would have collapsed the min year and exploded the gap-fill into thousands of rows — the loader now only counts plausible 4-digit years.

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors (22 baseline warnings) · 558 unit · 26 e2e. Preview-confirmed both modes:
- Year: 43 periods (1984–2026), newest-first.
- Year-Month: 80 periods — e.g. 2025 / Oct (MovinkPad Pro 14), 2025 / Sep (Wacom One 14), plus per-year "no month" buckets — same 349 tablet / 115 pen totals (nothing lost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)