### PR TITLE
feat(api-explorer): add "Pens tagged UDEMR" example

### DIFF
--- a/src/lib/api-explorer/presets.ts
+++ b/src/lib/api-explorer/presets.ts
@@ -31,6 +31,7 @@ export const PRESET_GROUPS: { group: string; labels: string[] }[] = [
 			'between operator: launch year range',
 			'Strict (case-sensitive) contains',
 			'Distinct values of a field',
+			'Pens tagged UDEMR',
 		],
 	},
 	{
@@ -185,6 +186,18 @@ return await ds.Tablets
 		label: 'Distinct values of a field',
 		body: `// .distinct() returns a sorted array of distinct non-empty values.
 return await ds.Tablets.filter('Brand', '==', 'WACOM').distinct('ModelType');`,
+	},
+	{
+		label: 'Pens tagged UDEMR',
+		body: `// Pens whose Tags array includes "UDEMR" (a universal/active EMR pen
+// tag — no tablet carries it; only pens have a Tags field). The Tags
+// FieldDef joins the array to a string, so the case-insensitive
+// 'contains' operator matches the tag.
+return await ds.Pens
+  .filter('Tags', 'contains', 'UDEMR')
+  .select(['Brand', 'PenId', 'PenName', 'Tags'])
+  .sort('Brand', 'asc')
+  .toArray();`,
 	},
 	{
 		label: 'Predicate-function filter',


### PR DESCRIPTION
Adds an API-explorer "Load example…" preset (under **Filtering**) that lists every pen tagged **UDEMR**:

```js
return await ds.Pens
  .filter('Tags', 'contains', 'UDEMR')
  .select(['Brand', 'PenId', 'PenName', 'Tags'])
  .sort('Brand', 'asc')
  .toArray();
```

### Tablets → pens
The request asked for *tablets* with a UDEMR tag, but **tablets have no `Tags` field** in the schema, and `UDEMR` appears only on **pens** (ASUS ProArt Pen, LAMY AL-star EMR, Samsung S Pen / S Pen Creator, Staedtler Mars Lumograph Digital, …). A tablet query would error / return nothing, so the example targets `ds.Pens`. The `Tags` FieldDef joins the array to a string, so the case-insensitive `contains` operator matches the tag.

### Verification
`npm run check` 0/0 · preset invariant test passes (4) · `npm run lint` 0 errors · 26 e2e. Preview-confirmed: loading the example and running it returns the 6 UDEMR-tagged pens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)