### PR TITLE
feat(timeline): add Drivers as a third category

### DIFF
--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { base, resolve } from '$app/paths';
 	import { untrack } from 'svelte';
-	import { brandName, type Tablet, type Pen } from '$data/lib/drawtab-loader.js';
+	import { brandName, type Tablet, type Pen, type Driver } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
 
 	let { data } = $props();
 
 	let tablets: Tablet[] = $derived(data.tablets);
 	let pens: Pen[] = $derived(data.pens);
+	let drivers: Driver[] = $derived(data.drivers);
 	let brands = $derived(data.brands);
+
+	const OS_LABELS: Record<string, string> = { MACOS: 'macOS', WINDOWS: 'Windows' };
 
 	let filterBrand = $state('');
 	let filterType = $state('');
@@ -42,6 +45,7 @@
 		monthUnknown: boolean; // year-month mode, item has no month
 		tablets: Tablet[];
 		pens: Pen[];
+		drivers: Driver[];
 	}
 
 	// Period bucket for an item. In year mode everything keys on the launch
@@ -73,10 +77,10 @@
 		// state — a plain Map is correct (no SvelteMap reactivity needed).
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const map = new Map<string, Period>();
-		const ensure = (k: Omit<Period, 'tablets' | 'pens'>) => {
+		const ensure = (k: Omit<Period, 'tablets' | 'pens' | 'drivers'>) => {
 			let p = map.get(k.sort);
 			if (!p) {
-				p = { ...k, tablets: [], pens: [] };
+				p = { ...k, tablets: [], pens: [], drivers: [] };
 				map.set(k.sort, p);
 			}
 			return p;
@@ -95,6 +99,14 @@
 			if (!inRange(p.PenYear)) continue;
 			ensure(periodKey(p.PenYear, undefined)).pens.push(p);
 		}
+		// Drivers carry a full ReleaseDate (no LaunchYear); the year is its first
+		// 4 chars. Like pens, drivers ignore the tablet-only type filter.
+		for (const d of drivers) {
+			if (filterBrand && d.Brand !== filterBrand) continue;
+			const year = (d.ReleaseDate ?? '').slice(0, 4);
+			if (!inRange(year)) continue;
+			ensure(periodKey(year, d.ReleaseDate)).drivers.push(d);
+		}
 
 		// Year mode fills empty years across the visible range so gaps read as
 		// "No releases". Year-month mode would explode into mostly-empty months,
@@ -103,7 +115,15 @@
 			for (let y = from; y <= to; y++) {
 				const k = String(y);
 				if (!map.has(k))
-					map.set(k, { sort: k, year: k, month: null, monthUnknown: false, tablets: [], pens: [] });
+					map.set(k, {
+						sort: k,
+						year: k,
+						month: null,
+						monthUnknown: false,
+						tablets: [],
+						pens: [],
+						drivers: [],
+					});
 			}
 		}
 
@@ -116,6 +136,7 @@
 
 	let totalTablets = $derived(groupedTimeline.reduce((sum, e) => sum + e.tablets.length, 0));
 	let totalPens = $derived(groupedTimeline.reduce((sum, e) => sum + e.pens.length, 0));
+	let totalDrivers = $derived(groupedTimeline.reduce((sum, e) => sum + e.drivers.length, 0));
 	let periodNoun = $derived(groupBy === 'year' ? 'years' : 'periods');
 </script>
 
@@ -124,7 +145,9 @@
 <div class="title-row">
 	<h1>Timeline</h1>
 	<span class="subtitle"
-		>{groupedTimeline.length} {periodNoun}, {totalTablets} tablets, {totalPens} pens</span
+		>{groupedTimeline.length}
+		{periodNoun}, {totalTablets} tablets, {totalPens} pens, {totalDrivers}
+		drivers</span
 	>
 </div>
 
@@ -169,7 +192,7 @@
 				{/if}
 			</div>
 			<div class="year-content">
-				{#if entry.tablets.length === 0 && entry.pens.length === 0}
+				{#if entry.tablets.length === 0 && entry.pens.length === 0 && entry.drivers.length === 0}
 					<p class="no-releases">No releases</p>
 				{/if}
 				{#if entry.tablets.length > 0}
@@ -207,6 +230,23 @@
 									<span class="item-brand">{brandName(p.Brand)}</span>
 									<span class="item-name">{p.PenName}</span>
 									<span class="item-id">{p.PenId}</span>
+								</a>
+							{/each}
+						</div>
+					</div>
+				{/if}
+				{#if entry.drivers.length > 0}
+					<div class="category">
+						<h3>Drivers ({entry.drivers.length})</h3>
+						<div class="items">
+							{#each entry.drivers as d (d.EntityId)}
+								<a
+									class="item driver"
+									href={resolve('/entity/[entityId]', { entityId: d.EntityId })}
+								>
+									<span class="item-brand">{brandName(d.Brand)}</span>
+									<span class="item-name">{d.DriverVersion}</span>
+									<span class="item-id">{OS_LABELS[d.OSFamily] ?? d.OSFamily}</span>
 								</a>
 							{/each}
 						</div>
@@ -364,7 +404,8 @@
 		background: var(--hover-bg);
 	}
 
-	.item.pen:hover {
+	.item.pen:hover,
+	.item.driver:hover {
 		border-color: var(--link);
 	}
 

--- a/src/routes/timeline/+page.ts
+++ b/src/routes/timeline/+page.ts
@@ -1,19 +1,29 @@
 export async function load({ parent }) {
 	const { ds } = await parent();
-	const [tablets, pens] = await Promise.all([ds.Tablets.toArray(), ds.Pens.toArray()]);
+	const [tablets, pens, drivers] = await Promise.all([
+		ds.Tablets.toArray(),
+		ds.Pens.toArray(),
+		ds.Drivers.toArray(),
+	]);
 
 	const brands = [
-		...new Set([...tablets.map((t) => t.Model.Brand), ...pens.map((p) => p.Brand)]),
+		...new Set([
+			...tablets.map((t) => t.Model.Brand),
+			...pens.map((p) => p.Brand),
+			...drivers.map((d) => d.Brand),
+		]),
 	].sort();
 
-	// Grouping (by year, or by year-month using tablet ReleaseDate) depends on a
-	// user toggle, so it lives in +page.svelte. The loader just hands over the
-	// raw entities plus the year range used to seed the From/To inputs.
+	// Grouping (by year, or by year-month using ReleaseDate) depends on a user
+	// toggle, so it lives in +page.svelte. The loader just hands over the raw
+	// entities plus the year range used to seed the From/To inputs.
 	// Number("") is 0, not NaN, so guard against blank years collapsing the
-	// range — only count plausible 4-digit years.
+	// range — only count plausible 4-digit years. Drivers contribute their
+	// ReleaseDate year.
 	const years = [
 		...tablets.map((t) => Number(t.Model.LaunchYear)),
 		...pens.map((p) => Number(p.PenYear)),
+		...drivers.map((d) => Number((d.ReleaseDate ?? '').slice(0, 4))),
 	].filter((y) => !isNaN(y) && y >= 1900 && y <= 2200);
 	const minYear = Math.min(...years);
 	const maxYear = Math.max(...years);
@@ -21,6 +31,7 @@ export async function load({ parent }) {
 	return {
 		tablets,
 		pens,
+		drivers,
 		brands,
 		minYear,
 		maxYear,


### PR DESCRIPTION
Drivers now appear on the **Timeline** alongside Tablets and Pens.

### Behavior
- Each period gains a **Drivers (N)** category (after Tablets/Pens) with rows showing **brand · version · OS** (macOS/Windows), linking to `/entity/<driver>`.
- Drivers bucket by their `ReleaseDate`. Since drivers carry **full ISO dates**, Year-Month mode places them in real month buckets (e.g. 2026 Apr → Wacom 6.4.13-4 Windows/macOS).
- Drivers honor the **Brand** and **year-range** filters; like pens, they ignore the tablet-only **Type** filter. Drivers with a blank `ReleaseDate` are excluded.
- The subtitle count and the empty-period "No releases" check now include drivers.
- Loader folds driver brands + ReleaseDate years into the brand list and year range.

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors · 26 e2e. Preview-confirmed:
- Year mode: "43 years, 349 tablets, 115 pens, **184 drivers**" (66 drivers with blank dates correctly excluded).
- Year-Month: 175 periods, drivers in real month buckets, totals preserved.

Note: 184 drivers add density to the timeline (mostly Wacom). The Brand filter narrows it; if you'd later want a per-kind show/hide toggle (Tablets/Pens/Drivers), happy to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)