### PR TITLE
feat: brand + in-inventory columns on family lists; tablet-inventory name/Model ID

### DIFF
--- a/src/lib/inventory-cell-links.ts
+++ b/src/lib/inventory-cell-links.ts
@@ -37,7 +37,9 @@ export function inventoryTabletCellLinks(
 		],
 		TabletEntityId: (item) => [
 			{
-				label: tabletNameMap.get(item.TabletEntityId) ?? item.TabletEntityId,
+				// Show the plain tablet name (Brand and Model ID are their own
+				// columns); fall back to the full-name map, then the EntityId.
+				label: item.ModelName || tabletNameMap.get(item.TabletEntityId) || item.TabletEntityId,
 				href: `${base}/entity/${encodeURIComponent(item.TabletEntityId)}`,
 			},
 		],

--- a/src/routes/pen-families/+page.ts
+++ b/src/routes/pen-families/+page.ts
@@ -1,12 +1,35 @@
-import { setPenFamilyMemberCounts } from '$data/lib/entities/pen-family-fields.js';
+import {
+	setPenFamilyMemberCounts,
+	setPenFamilyInventoryCounts,
+} from '$data/lib/entities/pen-family-fields.js';
 
 export async function load({ parent }) {
 	const { ds } = await parent();
-	const [families, pens] = await Promise.all([ds.PenFamilies.toArray(), ds.Pens.toArray()]);
+	const [families, pens, invPens] = await Promise.all([
+		ds.PenFamilies.toArray(),
+		ds.Pens.toArray(),
+		ds.InventoryPens.toArray(),
+	]);
+
+	// Pen-model count per family.
 	const counts: Record<string, number> = {};
+	const familyByPenEntityId = new Map<string, string>();
 	for (const p of pens) {
-		if (p.PenFamily) counts[p.PenFamily] = (counts[p.PenFamily] ?? 0) + 1;
+		if (p.PenFamily) {
+			counts[p.PenFamily] = (counts[p.PenFamily] ?? 0) + 1;
+			familyByPenEntityId.set(p.EntityId, p.PenFamily);
+		}
 	}
 	setPenFamilyMemberCounts(counts);
+
+	// Physical inventory pen units per family (unit → its pen's PenFamily).
+	const invCounts: Record<string, number> = {};
+	for (const inv of invPens) {
+		const fid = familyByPenEntityId.get(inv.PenEntityId);
+		if (!fid) continue;
+		invCounts[fid] = (invCounts[fid] ?? 0) + 1;
+	}
+	setPenFamilyInventoryCounts(invCounts);
+
 	return { families };
 }

--- a/src/routes/tablet-families/+page.ts
+++ b/src/routes/tablet-families/+page.ts
@@ -2,14 +2,17 @@ import type { TabletFamily } from '$data/lib/entities/tablet-family-fields.js';
 
 export async function load({ parent }) {
 	const { ds } = await parent();
-	const [families, tablets] = await Promise.all([
+	const [families, tablets, invTablets] = await Promise.all([
 		ds.TabletFamilies.toArray() as Promise<TabletFamily[]>,
 		ds.Tablets.toArray(),
+		ds.InventoryTablets.toArray(),
 	]);
 
-	// Build lookup: EntityId → { count, earliestYear }
+	// Build lookup: EntityId → { count, earliestYear } and tablet EntityId → Family.
 	const familyStats = new Map<string, { count: number; earliestYear: number }>();
+	const familyByTabletEntityId = new Map<string, string>();
 	for (const t of tablets) {
+		if (t.Model.Family) familyByTabletEntityId.set(t.Meta.EntityId, t.Model.Family);
 		const fid = t.Model.Family;
 		if (!fid) continue;
 		const year = parseInt(t.Model.LaunchYear ?? '');
@@ -22,11 +25,20 @@ export async function load({ parent }) {
 		}
 	}
 
+	// Count physical inventory tablet units per family (unit → its tablet's Family).
+	const inventoryCounts = new Map<string, number>();
+	for (const inv of invTablets) {
+		const fid = familyByTabletEntityId.get(inv.TabletEntityId);
+		if (!fid) continue;
+		inventoryCounts.set(fid, (inventoryCounts.get(fid) ?? 0) + 1);
+	}
+
 	const data = families.map((f) => {
 		const stats = familyStats.get(f.EntityId);
 		return {
 			...f,
 			_tabletCount: stats?.count ?? 0,
+			_inventoryCount: inventoryCounts.get(f.EntityId) ?? 0,
 			_earliestYear: stats && stats.earliestYear !== Infinity ? String(stats.earliestYear) : '',
 		};
 	});


### PR DESCRIPTION
Addresses three list-page requests.

### /tablet-families
- **Brand** column (field existed; added to the default view).
- **In Inventory** column — number of physical inventory tablet units belonging to the family (unit → its tablet's `Model.Family`).

### /pen-families
- **Brand** column.
- **In Inventory** column — number of physical inventory pen units belonging to the family (unit → its pen's `PenFamily`).

### /tablet-inventory
- The **Tablet** column now shows the plain tablet **name** (e.g. "Turing Basic M") instead of the full "Brand Name (Id)" — Brand has its own column.
- Replaced the redundant second name column with a **Model ID** column.

### Where
- data-repo (field defs / default views): `tablet-family-fields.ts`, `pen-family-fields.ts` (new `setPenFamilyInventoryCounts`), `inventory-tablet-fields.ts`.
- explorer: family route loaders compute the per-family inventory-unit counts; `inventory-cell-links` labels the Tablet column with `ModelName`. Submodule pointer bumped.

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors · 26 e2e. Preview-confirmed all three:
- tablet-families: `Brand · Name · Model Pattern · Tablets · In Inventory · Year` (e.g. DigiDraw Turing Basic → 2 tablets / 1 in inventory)
- pen-families: `Brand · Name · Pens · In Inventory` (e.g. Apple Pencil → 4 models / 7 units)
- tablet-inventory: `Inventory ID · Tablet (name, linked) · Brand · Model ID · Type · Vendor · Order Date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)