### PR TITLE
feat(data-quality): brand + Missing filters on the "No Exact Release Date" table

### DIFF
--- a/src/routes/data-quality/+page.svelte
+++ b/src/routes/data-quality/+page.svelte
@@ -50,6 +50,17 @@
 	let iafEstimatedNoMeasurement = $derived(analysis.iafEstimatedNoMeasurement);
 	let tabletsMissingExactReleaseDate = $derived(analysis.tabletsMissingExactReleaseDate);
 
+	// Brand filter for the "Tablets — No Exact Release Date" section.
+	let releaseDateBrand = $state('');
+	let releaseDateBrands = $derived(
+		[...new Set(tabletsMissingExactReleaseDate.map((t) => t.brand))].sort(),
+	);
+	let filteredReleaseDateTablets = $derived(
+		releaseDateBrand
+			? tabletsMissingExactReleaseDate.filter((t) => t.brand === releaseDateBrand)
+			: tabletsMissingExactReleaseDate,
+	);
+
 	// Source of truth for the navigation tree. `count` (optional) is
 	// re-read every render so the badge stays in sync with the derived
 	// state above.
@@ -641,14 +652,14 @@
 					<section class="section">
 						<SectionHeader
 							title="Tablets — No Exact Release Date"
-							count={tabletsMissingExactReleaseDate.length}
-							disabled={tabletsMissingExactReleaseDate.length === 0}
+							count={filteredReleaseDateTablets.length}
+							disabled={filteredReleaseDateTablets.length === 0}
 							onExport={() =>
 								openExport(
 									'Tablets Without an Exact Release Date',
 									'data-quality-tablet-release-dates',
 									['Brand', 'Model ID', 'Name', 'Current ReleaseDate', 'Missing'],
-									tabletsMissingExactReleaseDate.map((t) => [
+									filteredReleaseDateTablets.map((t) => [
 										t.brand,
 										t.id,
 										t.name,
@@ -666,6 +677,15 @@
 								>Every tablet has an exact (YYYY-MM-DD) release date.</StatusMessage
 							>
 						{:else}
+							<label class="dq-filter">
+								Brand:
+								<select bind:value={releaseDateBrand}>
+									<option value="">All ({tabletsMissingExactReleaseDate.length})</option>
+									{#each releaseDateBrands as b (b)}
+										<option value={b}>{b}</option>
+									{/each}
+								</select>
+							</label>
 							<table class="compact">
 								<thead>
 									<tr>
@@ -676,7 +696,7 @@
 									</tr>
 								</thead>
 								<tbody>
-									{#each tabletsMissingExactReleaseDate as t (t.entityId)}
+									{#each filteredReleaseDateTablets as t (t.entityId)}
 										<tr>
 											<td>{t.brand}</td>
 											<td>
@@ -925,6 +945,24 @@
 		font-size: 13px;
 		color: #888;
 		margin-bottom: 8px;
+	}
+
+	.dq-filter {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 13px;
+		color: var(--text-muted);
+		margin-bottom: 8px;
+	}
+
+	.dq-filter select {
+		padding: 4px 8px;
+		font-size: 13px;
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		background: var(--bg-card);
+		color: var(--text);
 	}
 
 	table {

--- a/src/routes/data-quality/+page.svelte
+++ b/src/routes/data-quality/+page.svelte
@@ -50,15 +50,21 @@
 	let iafEstimatedNoMeasurement = $derived(analysis.iafEstimatedNoMeasurement);
 	let tabletsMissingExactReleaseDate = $derived(analysis.tabletsMissingExactReleaseDate);
 
-	// Brand filter for the "Tablets — No Exact Release Date" section.
+	// Brand + Missing filters for the "Tablets — No Exact Release Date" section.
 	let releaseDateBrand = $state('');
+	let releaseDateMissing = $state('');
 	let releaseDateBrands = $derived(
 		[...new Set(tabletsMissingExactReleaseDate.map((t) => t.brand))].sort(),
 	);
+	let releaseDateMissingKinds = $derived(
+		[...new Set(tabletsMissingExactReleaseDate.map((t) => t.missing))].sort(),
+	);
 	let filteredReleaseDateTablets = $derived(
-		releaseDateBrand
-			? tabletsMissingExactReleaseDate.filter((t) => t.brand === releaseDateBrand)
-			: tabletsMissingExactReleaseDate,
+		tabletsMissingExactReleaseDate.filter(
+			(t) =>
+				(!releaseDateBrand || t.brand === releaseDateBrand) &&
+				(!releaseDateMissing || t.missing === releaseDateMissing),
+		),
 	);
 
 	// Source of truth for the navigation tree. `count` (optional) is
@@ -677,15 +683,26 @@
 								>Every tablet has an exact (YYYY-MM-DD) release date.</StatusMessage
 							>
 						{:else}
-							<label class="dq-filter">
-								Brand:
-								<select bind:value={releaseDateBrand}>
-									<option value="">All ({tabletsMissingExactReleaseDate.length})</option>
-									{#each releaseDateBrands as b (b)}
-										<option value={b}>{b}</option>
-									{/each}
-								</select>
-							</label>
+							<div class="dq-filters">
+								<label class="dq-filter">
+									Brand:
+									<select bind:value={releaseDateBrand}>
+										<option value="">All ({tabletsMissingExactReleaseDate.length})</option>
+										{#each releaseDateBrands as b (b)}
+											<option value={b}>{b}</option>
+										{/each}
+									</select>
+								</label>
+								<label class="dq-filter">
+									Missing:
+									<select bind:value={releaseDateMissing}>
+										<option value="">All</option>
+										{#each releaseDateMissingKinds as m (m)}
+											<option value={m}>{m}</option>
+										{/each}
+									</select>
+								</label>
+							</div>
 							<table class="compact">
 								<thead>
 									<tr>
@@ -947,13 +964,19 @@
 		margin-bottom: 8px;
 	}
 
+	.dq-filters {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 16px;
+		margin-bottom: 8px;
+	}
+
 	.dq-filter {
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
 		font-size: 13px;
 		color: var(--text-muted);
-		margin-bottom: 8px;
 	}
 
 	.dq-filter select {


### PR DESCRIPTION
Adds two filters to the [Tablets — No Exact Release Date](https://thesevenpens.github.io/DrawTabDataExplorer/data-quality#tablet-release-dates) section:

- **Brand** — All (N) plus each brand present in the list.
- **Missing** — All plus each value of the *Missing* column (`missing`, `year only (no month/day)`, `month only (no day)`).

The two combine (AND), and the section header **count** + **CSV export** both follow the filtered set.

Explorer-only — the section's data already comes from `analysis.ts`; this adds local `$state` + a `$derived` filtered list and two `<select>`s.

### Verification
`npm run check` 0/0 · `npm run lint` 0 errors · 26 e2e. Preview-confirmed: Brand=WACOM alone → 66/187; Brand=WACOM + Missing="year only" → 14 rows (all matching), header "(14)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)