### PR TITLE
feat(data-quality): flag duplicate pen/tablet inventory ids in the UI

### DIFF
--- a/src/lib/data-quality/analysis.test.ts
+++ b/src/lib/data-quality/analysis.test.ts
@@ -143,6 +143,41 @@ describe('analyzeData — tabletsMissingExactReleaseDate', () => {
 	});
 });
 
+describe('analyzeData — duplicate inventory ids', () => {
+	it('flags duplicate pen and tablet inventory ids independently, exempting UNASSIGNED', () => {
+		const input: AnalysisInput = {
+			...emptyInput(),
+			invPens: [
+				invPen({ InventoryId: 'WAP.A', _id: 'i1' }),
+				invPen({ InventoryId: 'WAP.A', _id: 'i2' }), // duplicate → flagged
+				invPen({ InventoryId: 'WAP.B', _id: 'i3' }), // unique
+				invPen({ InventoryId: 'UNASSIGNED', _id: 'i4' }),
+				invPen({ InventoryId: 'UNASSIGNED', _id: 'i5' }), // placeholder → exempt
+			],
+			invTablets: [
+				{ InventoryId: 'WAT.A', TabletEntityId: 'wacom.tablet.a', _id: 't1' },
+				{ InventoryId: 'WAT.A', TabletEntityId: 'wacom.tablet.a', _id: 't2' }, // duplicate
+			] as unknown as AnalysisInput['invTablets'],
+		};
+		const dups = analyzeData(input).issues.filter((i) => i.issue === 'duplicate InventoryId');
+		expect(dups).toHaveLength(2);
+		expect(dups.some((i) => i.entity === 'InventoryPen' && i.entityId === 'WAP.A')).toBe(true);
+		expect(dups.some((i) => i.entity === 'InventoryTablet' && i.entityId === 'WAT.A')).toBe(true);
+	});
+
+	it('reports no duplicates when all inventory ids are unique', () => {
+		const input: AnalysisInput = {
+			...emptyInput(),
+			invPens: [
+				invPen({ InventoryId: 'WAP.A', _id: 'i1' }),
+				invPen({ InventoryId: 'WAP.B', _id: 'i2' }),
+			],
+		};
+		const dups = analyzeData(input).issues.filter((i) => i.issue === 'duplicate InventoryId');
+		expect(dups).toHaveLength(0);
+	});
+});
+
 describe('analyzeData — pressure-range integrity', () => {
 	const base: AnalysisInput = {
 		...emptyInput(),

--- a/src/lib/data-quality/analysis.ts
+++ b/src/lib/data-quality/analysis.ts
@@ -24,6 +24,7 @@ import { buildInventoryDefects } from '$data/lib/pressure/defects.js';
 import {
 	checkRequired,
 	checkWhitespace,
+	checkDuplicateInventoryIds,
 	computeCompletion,
 	findOrphanedCompat,
 	type DataBundle,
@@ -132,6 +133,11 @@ export function analyzeData(data: AnalysisInput) {
 	allIssues.push(...checkWhitespace(ds.drivers, 'Driver'));
 	allIssues.push(...checkWhitespace(ds.pressureResponse, 'PressureResponse'));
 	allIssues.push(...checkWhitespace(pressureRange, 'PressureRange'));
+
+	// Inventory id uniqueness — pen and tablet collections checked independently
+	// (a pen and a tablet may legitimately share an id string).
+	allIssues.push(...checkDuplicateInventoryIds(invPens, 'InventoryPen'));
+	allIssues.push(...checkDuplicateInventoryIds(invTablets, 'InventoryTablet'));
 
 	// Direct pressure-range measurement integrity: the PenInventoryId must
 	// resolve to an owned inventory pen, the (optional) TabletEntityId to a

--- a/src/lib/data-quality/helpers.ts
+++ b/src/lib/data-quality/helpers.ts
@@ -106,6 +106,36 @@ export function checkWhitespace(records: Record<string, any>[], entity: string):
 	return found;
 }
 
+// Inventory ids must be unique within their collection — a repeated
+// InventoryId makes per-unit lookups (pressure measurements/sessions keyed on
+// it) ambiguous, so a measurement can attach to the wrong physical unit.
+// "UNASSIGNED" is a repeatable placeholder, so it's exempt. Mirrors the CLI's
+// runInventoryDuplicateCheck in data-repo/lib/data-quality.ts.
+export function checkDuplicateInventoryIds(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	records: Record<string, any>[],
+	entity: string,
+): Issue[] {
+	const found: Issue[] = [];
+	const seen = new Set<string>();
+	for (const rec of records) {
+		const invId = rec.InventoryId;
+		if (typeof invId !== 'string' || invId === '' || invId === 'UNASSIGNED') continue;
+		if (seen.has(invId)) {
+			found.push({
+				entity,
+				entityId: invId,
+				field: 'InventoryId',
+				issue: 'duplicate InventoryId',
+				value: rec.PenEntityId ?? rec.TabletEntityId,
+			});
+		} else {
+			seen.add(invId);
+		}
+	}
+	return found;
+}
+
 export function computeCompletion(
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	records: Record<string, any>[],


### PR DESCRIPTION
## What

Adds two data-quality checks to the **browser** data-quality page:
- **duplicate pen inventory ids** (across `InventoryPens`)
- **duplicate tablet inventory ids** (across `InventoryTablets`)

checked independently (a pen and a tablet may legitimately share an id string), with `"UNASSIGNED"` placeholders exempt.

## Why

The CLI (`data-repo/lib/data-quality.ts`) already has `runInventoryDuplicateCheck`, but the browser page only validated inventory *references* (PenInventoryId → owned pen) — not inventory-id *uniqueness*. A duplicate id makes per-unit lookups ambiguous (a measurement can attach to the wrong physical unit — exactly the kind of collision behind the recent WAP.0074 split). This brings the UI to parity with the CLI.

## How

- New pure helper `checkDuplicateInventoryIds(records, entity)` in `src/lib/data-quality/helpers.ts`.
- `analyzeData` calls it for `invPens` (`InventoryPen`) and `invTablets` (`InventoryTablet`); results flow into the existing **Issues** table — no `+page.svelte` change.
- Unit tests cover the duplicate-detection, the per-collection namespacing, the `UNASSIGNED` exemption, and the all-unique case.

## Verification

- `npm run check` — 0 errors
- `npm run test:unit` (data-quality) — 7 passed (incl. 2 new)
- `npm run lint` — 0 errors (pre-existing warnings only); Prettier clean
- `npm run test:e2e` — 26 passed

No current data triggers the new checks (the only real collision was already fixed), so there's no new on-screen output yet — the checks are dormant until a duplicate is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)