### PR TITLE
feat(nav): Timeline & Pressure Response under Data; Timeline table view

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -27,15 +27,19 @@
 				'/pen-inventory',
 				'/pen-flagged',
 				'/pen-compare',
-				'/pressure-response',
 			],
 		},
 		{ href: '/drivers', label: 'Drivers' },
-		{ href: '/timeline', label: 'Timeline' },
 		{
 			href: '/reference',
 			label: 'Data',
-			altActive: ['/data-dictionary', '/api-explorer', '/data-quality'],
+			altActive: [
+				'/data-dictionary',
+				'/timeline',
+				'/pressure-response',
+				'/api-explorer',
+				'/data-quality',
+			],
 		},
 		{ href: '/about', label: 'About' },
 	];

--- a/src/lib/nav/subnav-tabs.ts
+++ b/src/lib/nav/subnav-tabs.ts
@@ -22,6 +22,8 @@ export function dataSubNavTabs(): SubNavTab[] {
 	return [
 		{ href: '/reference', label: 'Reference' },
 		{ href: '/data-dictionary', label: 'Data Dictionary' },
+		{ href: '/timeline', label: 'Timeline' },
+		{ href: '/pressure-response', label: 'Pressure Response' },
 		{ href: '/api-explorer', label: 'API Explorer' },
 		{ href: '/data-quality', label: 'Data Quality' },
 	];
@@ -37,6 +39,5 @@ export function penSubNavTabs(
 		{ href: '/pen-inventory', label: 'Inventory' },
 		{ href: '/pen-flagged', label: 'Flagged', badge: opts.flaggedPenCount },
 		{ href: '/pen-compare', label: 'Compare', badge: opts.flaggedPenModelCount },
-		{ href: '/pressure-response', label: 'Pressure Response' },
 	];
 }

--- a/src/lib/timeline/rows.test.ts
+++ b/src/lib/timeline/rows.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { buildTimelineRows, type TimelinePeriod } from './rows.js';
+import type { Tablet, Pen, Driver } from '$data/lib/drawtab-loader.js';
+
+const tablet = (id: string): Tablet =>
+	({
+		Meta: { EntityId: `wacom.tablet.${id.toLowerCase()}` },
+		Model: { Brand: 'WACOM', Id: id, Name: `Tablet ${id}`, Type: 'PENTABLET' },
+	}) as unknown as Tablet;
+
+const pen = (id: string): Pen =>
+	({
+		EntityId: `wacom.pen.${id.toLowerCase()}`,
+		Brand: 'WACOM',
+		PenId: id,
+		PenName: `Pen ${id}`,
+	}) as unknown as Pen;
+
+const driver = (ver: string, os: string): Driver =>
+	({
+		EntityId: `wacom.driver.${ver}_${os.toLowerCase()}`,
+		Brand: 'WACOM',
+		DriverVersion: ver,
+		OSFamily: os,
+	}) as unknown as Driver;
+
+const period = (over: Partial<TimelinePeriod>): TimelinePeriod => ({
+	sort: '2020',
+	year: '2020',
+	month: null,
+	monthUnknown: false,
+	tablets: [],
+	pens: [],
+	drivers: [],
+	...over,
+});
+
+describe('buildTimelineRows', () => {
+	it('flattens periods in order, tablets then pens then drivers within a period', () => {
+		const rows = buildTimelineRows([
+			period({
+				sort: '2021',
+				year: '2021',
+				tablets: [tablet('A')],
+				pens: [pen('P')],
+				drivers: [driver('1.0', 'MACOS')],
+			}),
+			period({ sort: '2020', year: '2020', tablets: [tablet('B')] }),
+		]);
+		expect(rows.map((r) => [r.year, r.category, r.id])).toEqual([
+			['2021', 'Tablet', 'A'],
+			['2021', 'Pen', 'P'],
+			['2021', 'Driver', ''],
+			['2020', 'Tablet', 'B'],
+		]);
+	});
+
+	it('maps fields per category (driver OS goes in detail, id blank)', () => {
+		const [t, p, d] = buildTimelineRows([
+			period({ tablets: [tablet('A')], pens: [pen('P')], drivers: [driver('6.4.0', 'WINDOWS')] }),
+		]);
+		expect(t).toMatchObject({
+			category: 'Tablet',
+			name: 'Tablet A',
+			id: 'A',
+			detail: 'PENTABLET',
+			entityId: 'wacom.tablet.a',
+		});
+		expect(p).toMatchObject({ category: 'Pen', name: 'Pen P', id: 'P', detail: '' });
+		expect(d).toMatchObject({ category: 'Driver', name: '6.4.0', id: '', detail: 'Windows' });
+	});
+
+	it('carries period month metadata onto rows and skips empty periods', () => {
+		const rows = buildTimelineRows([
+			period({ sort: '2020-03', year: '2020', month: 3, tablets: [tablet('A')] }),
+			period({ sort: '2019', year: '2019' }), // empty → no rows
+		]);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ year: '2020', month: 3, monthUnknown: false });
+	});
+});

--- a/src/lib/timeline/rows.ts
+++ b/src/lib/timeline/rows.ts
@@ -1,0 +1,80 @@
+import type { Tablet, Pen, Driver } from '$data/lib/drawtab-loader.js';
+
+// One grouped period of the timeline (a year, or a year-month). Built in the
+// timeline page's grouping pass; shared with the table view so both render
+// from the same filtered/sorted data.
+export interface TimelinePeriod {
+	sort: string;
+	year: string;
+	month: number | null; // 1-12 when known
+	monthUnknown: boolean; // year-month mode, item has no month
+	tablets: Tablet[];
+	pens: Pen[];
+	drivers: Driver[];
+}
+
+export interface TimelineRow {
+	periodSort: string;
+	year: string;
+	month: number | null;
+	monthUnknown: boolean;
+	category: 'Tablet' | 'Pen' | 'Driver';
+	brand: string; // raw brand code; format with brandName() at render
+	name: string;
+	id: string;
+	detail: string; // tablet Type / driver OS label; '' for pens
+	entityId: string;
+}
+
+const OS_LABELS: Record<string, string> = { MACOS: 'macOS', WINDOWS: 'Windows' };
+
+// Flatten the grouped periods into a single ordered row list for the table
+// view. Period order (and thus sort direction) is preserved from the input;
+// within a period the order is tablets, then pens, then drivers — matching the
+// timeline view's section order. Empty periods (the "No releases" filler years
+// in year mode) contribute no rows.
+export function buildTimelineRows(periods: TimelinePeriod[]): TimelineRow[] {
+	const rows: TimelineRow[] = [];
+	for (const p of periods) {
+		const base = {
+			periodSort: p.sort,
+			year: p.year,
+			month: p.month,
+			monthUnknown: p.monthUnknown,
+		};
+		for (const t of p.tablets) {
+			rows.push({
+				...base,
+				category: 'Tablet',
+				brand: t.Model.Brand,
+				name: t.Model.Name,
+				id: t.Model.Id,
+				detail: t.Model.Type,
+				entityId: t.Meta.EntityId,
+			});
+		}
+		for (const pen of p.pens) {
+			rows.push({
+				...base,
+				category: 'Pen',
+				brand: pen.Brand,
+				name: pen.PenName,
+				id: pen.PenId,
+				detail: '',
+				entityId: pen.EntityId,
+			});
+		}
+		for (const d of p.drivers) {
+			rows.push({
+				...base,
+				category: 'Driver',
+				brand: d.Brand,
+				name: d.DriverVersion,
+				id: '',
+				detail: OS_LABELS[d.OSFamily] ?? d.OSFamily,
+				entityId: d.EntityId,
+			});
+		}
+	}
+	return rows;
+}

--- a/src/routes/pressure-response/+page.svelte
+++ b/src/routes/pressure-response/+page.svelte
@@ -7,12 +7,11 @@
 	import SubNav from '$lib/components/SubNav.svelte';
 	import PressureResponseChart from '$lib/components/PressureResponseChart.svelte';
 	import SessionStats from '$lib/components/SessionStats.svelte';
-	import { flaggedPenTotalCount } from '$lib/flagged-store.js';
-	import { penSubNavTabs } from '$lib/nav/subnav-tabs.js';
+	import { dataSubNavTabs } from '$lib/nav/subnav-tabs.js';
 
 	let { data } = $props();
 
-	let penTabs = $derived(penSubNavTabs({ flaggedPenCount: $flaggedPenTotalCount }));
+	const dataTabs = dataSubNavTabs();
 
 	let sessions = $derived(data.sessions);
 	let pens = $derived(data.pens);
@@ -78,7 +77,7 @@
 </script>
 
 <Nav />
-<SubNav tabs={penTabs} />
+<SubNav tabs={dataTabs} />
 
 <div class="header">
 	<h1>Pressure Response</h1>

--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -3,8 +3,15 @@
 	import { untrack } from 'svelte';
 	import { brandName, type Tablet, type Pen, type Driver } from '$data/lib/drawtab-loader.js';
 	import Nav from '$lib/components/Nav.svelte';
+	import SubNav from '$lib/components/SubNav.svelte';
+	import SegmentedControl from '$lib/components/SegmentedControl.svelte';
+	import { dataSubNavTabs } from '$lib/nav/subnav-tabs.js';
+	import { buildTimelineRows, type TimelinePeriod } from '$lib/timeline/rows.js';
 
 	let { data } = $props();
+
+	const dataTabs = dataSubNavTabs();
+	let view: 'timeline' | 'table' = $state('timeline');
 
 	let tablets: Tablet[] = $derived(data.tablets);
 	let pens: Pen[] = $derived(data.pens);
@@ -38,15 +45,7 @@
 		'Dec',
 	];
 
-	interface Period {
-		sort: string;
-		year: string;
-		month: number | null; // 1-12 when known
-		monthUnknown: boolean; // year-month mode, item has no month
-		tablets: Tablet[];
-		pens: Pen[];
-		drivers: Driver[];
-	}
+	type Period = TimelinePeriod;
 
 	// Period bucket for an item. In year mode everything keys on the launch
 	// year. In year-month mode, tablets with a month-precision ReleaseDate
@@ -134,6 +133,10 @@
 		return periods;
 	});
 
+	// Table view shares the same filtered/grouped/sorted periods, flattened to
+	// one row per entity (in period then tablet/pen/driver order).
+	let tableRows = $derived(buildTimelineRows(groupedTimeline));
+
 	let totalTablets = $derived(groupedTimeline.reduce((sum, e) => sum + e.tablets.length, 0));
 	let totalPens = $derived(groupedTimeline.reduce((sum, e) => sum + e.pens.length, 0));
 	let totalDrivers = $derived(groupedTimeline.reduce((sum, e) => sum + e.drivers.length, 0));
@@ -141,6 +144,7 @@
 </script>
 
 <Nav />
+<SubNav tabs={dataTabs} />
 
 <div class="title-row">
 	<h1>Timeline</h1>
@@ -149,6 +153,14 @@
 		{periodNoun}, {totalTablets} tablets, {totalPens} pens, {totalDrivers}
 		drivers</span
 	>
+	<SegmentedControl
+		options={[
+			{ value: 'timeline', label: 'Timeline' },
+			{ value: 'table', label: 'Table' },
+		]}
+		bind:value={view}
+		ariaLabel="View"
+	/>
 </div>
 
 <div class="filters">
@@ -180,82 +192,116 @@
 	</span>
 </div>
 
-<div class="timeline">
-	{#each groupedTimeline as entry (entry.sort)}
-		<div class="year-block">
-			<div class="year-label">
-				<span class="period-year">{entry.year}</span>
-				{#if entry.month}
-					<span class="period-month">{MONTHS[entry.month]}</span>
-				{:else if entry.monthUnknown}
-					<span class="period-month dim">no month</span>
-				{/if}
-			</div>
-			<div class="year-content">
-				{#if entry.tablets.length === 0 && entry.pens.length === 0 && entry.drivers.length === 0}
-					<p class="no-releases">No releases</p>
-				{/if}
-				{#if entry.tablets.length > 0}
-					<div class="category">
-						<h3>Tablets ({entry.tablets.length})</h3>
-						<div class="items">
-							{#each entry.tablets as t (t.Meta.EntityId)}
-								<div
-									class="item tablet"
-									role="link"
-									tabindex="0"
-									ondblclick={() => {
-										window.location.href = `${base}/entity/${encodeURIComponent(t.Meta.EntityId)}`;
-									}}
-									onkeydown={(e) => {
-										if (e.key === 'Enter')
+{#if view === 'timeline'}
+	<div class="timeline">
+		{#each groupedTimeline as entry (entry.sort)}
+			<div class="year-block">
+				<div class="year-label">
+					<span class="period-year">{entry.year}</span>
+					{#if entry.month}
+						<span class="period-month">{MONTHS[entry.month]}</span>
+					{:else if entry.monthUnknown}
+						<span class="period-month dim">no month</span>
+					{/if}
+				</div>
+				<div class="year-content">
+					{#if entry.tablets.length === 0 && entry.pens.length === 0 && entry.drivers.length === 0}
+						<p class="no-releases">No releases</p>
+					{/if}
+					{#if entry.tablets.length > 0}
+						<div class="category">
+							<h3>Tablets ({entry.tablets.length})</h3>
+							<div class="items">
+								{#each entry.tablets as t (t.Meta.EntityId)}
+									<div
+										class="item tablet"
+										role="link"
+										tabindex="0"
+										ondblclick={() => {
 											window.location.href = `${base}/entity/${encodeURIComponent(t.Meta.EntityId)}`;
-									}}
-								>
-									<span class="item-brand">{brandName(t.Model.Brand)}</span>
-									<span class="item-name">{t.Model.Name}</span>
-									<span class="item-id">{t.Model.Id}</span>
-									<span class="item-type">{t.Model.Type}</span>
-								</div>
-							{/each}
+										}}
+										onkeydown={(e) => {
+											if (e.key === 'Enter')
+												window.location.href = `${base}/entity/${encodeURIComponent(t.Meta.EntityId)}`;
+										}}
+									>
+										<span class="item-brand">{brandName(t.Model.Brand)}</span>
+										<span class="item-name">{t.Model.Name}</span>
+										<span class="item-id">{t.Model.Id}</span>
+										<span class="item-type">{t.Model.Type}</span>
+									</div>
+								{/each}
+							</div>
 						</div>
-					</div>
-				{/if}
-				{#if entry.pens.length > 0}
-					<div class="category">
-						<h3>Pens ({entry.pens.length})</h3>
-						<div class="items">
-							{#each entry.pens as p (p.EntityId)}
-								<a class="item pen" href={resolve('/entity/[entityId]', { entityId: p.EntityId })}>
-									<span class="item-brand">{brandName(p.Brand)}</span>
-									<span class="item-name">{p.PenName}</span>
-									<span class="item-id">{p.PenId}</span>
-								</a>
-							{/each}
+					{/if}
+					{#if entry.pens.length > 0}
+						<div class="category">
+							<h3>Pens ({entry.pens.length})</h3>
+							<div class="items">
+								{#each entry.pens as p (p.EntityId)}
+									<a
+										class="item pen"
+										href={resolve('/entity/[entityId]', { entityId: p.EntityId })}
+									>
+										<span class="item-brand">{brandName(p.Brand)}</span>
+										<span class="item-name">{p.PenName}</span>
+										<span class="item-id">{p.PenId}</span>
+									</a>
+								{/each}
+							</div>
 						</div>
-					</div>
-				{/if}
-				{#if entry.drivers.length > 0}
-					<div class="category">
-						<h3>Drivers ({entry.drivers.length})</h3>
-						<div class="items">
-							{#each entry.drivers as d (d.EntityId)}
-								<a
-									class="item driver"
-									href={resolve('/entity/[entityId]', { entityId: d.EntityId })}
-								>
-									<span class="item-brand">{brandName(d.Brand)}</span>
-									<span class="item-name">{d.DriverVersion}</span>
-									<span class="item-id">{OS_LABELS[d.OSFamily] ?? d.OSFamily}</span>
-								</a>
-							{/each}
+					{/if}
+					{#if entry.drivers.length > 0}
+						<div class="category">
+							<h3>Drivers ({entry.drivers.length})</h3>
+							<div class="items">
+								{#each entry.drivers as d (d.EntityId)}
+									<a
+										class="item driver"
+										href={resolve('/entity/[entityId]', { entityId: d.EntityId })}
+									>
+										<span class="item-brand">{brandName(d.Brand)}</span>
+										<span class="item-name">{d.DriverVersion}</span>
+										<span class="item-id">{OS_LABELS[d.OSFamily] ?? d.OSFamily}</span>
+									</a>
+								{/each}
+							</div>
 						</div>
-					</div>
-				{/if}
+					{/if}
+				</div>
 			</div>
-		</div>
-	{/each}
-</div>
+		{/each}
+	</div>
+{:else}
+	<table class="timeline-table">
+		<thead>
+			<tr>
+				<th>Period</th>
+				<th>Category</th>
+				<th>Brand</th>
+				<th>Name</th>
+				<th>ID</th>
+				<th>Details</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each tableRows as row (row.entityId)}
+				<tr>
+					<td class="period-cell">
+						{row.year}{#if row.month}<span class="dim"> {MONTHS[row.month]}</span>
+						{:else if row.monthUnknown}<span class="dim"> no month</span>{/if}
+					</td>
+					<td>{row.category}</td>
+					<td>{brandName(row.brand)}</td>
+					<td><a href={resolve('/entity/[entityId]', { entityId: row.entityId })}>{row.name}</a></td
+					>
+					<td class="mono">{row.id}</td>
+					<td>{row.detail}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
 
 <style>
 	.title-row {
@@ -429,5 +475,51 @@
 		font-size: 10px;
 		color: var(--text-dim);
 		text-transform: uppercase;
+	}
+
+	.timeline-table {
+		border-collapse: collapse;
+		font-size: 13px;
+		width: 100%;
+	}
+
+	.timeline-table th,
+	.timeline-table td {
+		padding: 5px 12px;
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+		white-space: nowrap;
+	}
+
+	.timeline-table th {
+		font-weight: 600;
+		color: var(--th-text);
+		background: var(--th-bg);
+		position: sticky;
+		top: 0;
+	}
+
+	.timeline-table td a {
+		color: var(--link);
+		text-decoration: none;
+	}
+
+	.timeline-table td a:hover {
+		text-decoration: underline;
+	}
+
+	.timeline-table .period-cell {
+		font-weight: 600;
+	}
+
+	.timeline-table .dim {
+		font-weight: 400;
+		color: var(--text-dim);
+	}
+
+	.timeline-table .mono {
+		font-family: ui-monospace, 'Cascadia Mono', Menlo, monospace;
+		font-size: 12px;
+		color: var(--text-muted);
 	}
 </style>


### PR DESCRIPTION
## Navigation restructure
- **Timeline** is no longer a top-level nav tab — it's now a sub-tab of **Data**.
- The **Pressure Response** tab moves out of **Pens** and into **Data**.
- `dataSubNavTabs` now: Reference · Data Dictionary · **Timeline** · **Pressure Response** · API Explorer · Data Quality. `penSubNavTabs` drops Pressure Response. `Nav.svelte` `altActive` sets updated so the **Data** tab highlights on `/timeline` and `/pressure-response` (and Pens no longer claims `/pressure-response`).
- Both routes now render the Data sub-nav.

## Timeline table view
- A `Timeline | Table` toggle (`SegmentedControl`) switches between the existing timeline and a flat table.
- Both views derive from the **same** grouped/filtered/sorted periods, so **Brand / Type / Group-by / Sort / year-range all apply identically** — verified live (e.g. Brand=APPLE → 666→39 rows).
- Table columns: Period · Category · Brand · Name (linked to the entity page) · ID · Details (tablet Type / driver OS).
- Extracted `buildTimelineRows()` (pure) into `src/lib/timeline/rows.ts` with unit tests; the page reuses its `TimelinePeriod` type.

## Verification
- `npm run check` — 0 errors
- `npm run test:unit` — passing (3 new `buildTimelineRows` tests)
- `npm run lint` — 0 errors (pre-existing warnings only); Prettier clean
- `npm run test:e2e` — 26 passed
- Browser preview: top nav drops Timeline; Data sub-nav shows both new tabs and highlights correctly; table renders 666 rows; filtering flows through; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)